### PR TITLE
Refresh site bio and CV content for Aakash Solanki

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+aakashsolanki.net

--- a/_config.yml
+++ b/_config.yml
@@ -2,22 +2,23 @@
 # Site settings
 # -----------------------------------------------------------------------------
 
-title: blank # the website title (if blank, full name will be used instead)
+title: Aakash Solanki # the website title (if blank, full name will be used instead)
 first_name: Aakash
-middle_name: 
+middle_name:
 last_name: Solanki
-email: # mail@aakashsolanki.net
+email: mail@aakashsolanki.net
 description: > # the ">" symbol means to ignore newlines until "footer_text:"
-  A simple, whitespace theme for academics. Based on [*folio](https://github.com/bogoli/-folio) design.
+  Anthropologist of data and the state researching how bureaucratic infrastructures, digital governance,
+  and classificatory systems shape social life across South Asia.
 footer_text: >
   Powered by <a href="https://jekyllrb.com/" target="_blank">Jekyll</a> with <a href="https://github.com/alshedivat/al-folio">al-folio</a> theme.
   Hosted by <a href="https://pages.github.com/" target="_blank">GitHub Pages</a>.
   
-keywords: # add your own keywords or leave empty jekyll, jekyll-theme, academic-website, portfolio-website # Photos from <a href="https://unsplash.com" target="_blank">Unsplash</a>.
+keywords: anthropology, digital governance, data infrastructures, colonial archives, South Asia
 lang: en # the language of your site (for example: en, fr, cn, ru, etc.)
 icon: ⚛️ # the emoji used as the favicon (alternatively, provide image name in /assets/img/)
 
-url: https://skishchampi.github.io # the base hostname & protocol for your site
+url: https://aakashsolanki.net # the base hostname & protocol for your site
 baseurl: # the subpath of your site, e.g. /blog/. Leave blank for root
 last_updated: true # set to true if you want to display last updated in the footer
 impressum_path: # set to path to include impressum link in the footer, use the same path as permalink in a page, helps to conform with EU GDPR
@@ -78,7 +79,7 @@ dblp_url: # your DBLP profile url
 discord_id: # your discord id (18-digit unique numerical identifier)
 facebook_id: # your facebook id
 flickr_id: # your flickr id
-github_username: # your GitHub user name
+github_username: AakashSolanki # your GitHub user name
 gitlab_username: # your GitLab user name
 ieee_id: # your ieeexplore.ieee.org/author/id
 inspirehep_id: # Inspire HEP author ID 1010907
@@ -87,10 +88,10 @@ kaggle_id: # your kaggle id
 keybase_username: # your keybase user name
 lastfm_id: # your lastfm id
 lattes_id: # your ID on Lattes (Brazilian Lattes CV)
-linkedin_username: # your LinkedIn user name solankiaakash
+linkedin_username: solankiaakash # your LinkedIn user name
 mastodon_username: # your mastodon instance+username in the format instance.tld/@username
 medium_username: # your Medium username
-orcid_id: # your ORCID ID 0000-0002-4879-6998 
+orcid_id: 0000-0002-4879-6998 # your ORCID ID
 osf_id: # your OSF ID
 pinterest_id: # your pinterest id
 publons_id: # your ID on Publons
@@ -108,7 +109,7 @@ whatsapp_number: # your WhatsApp number (full phone number in international form
 wikidata_id: # your wikidata id
 wikipedia_id: # your wikipedia id (Case sensitive)
 work_url: https://utsc.utoronto.ca/anthropology/aakash-solanki # work page URL
-x_username: # your X handle theplaa
+x_username: theplaa # your X handle
 youtube_id: # your youtube channel id (youtube.com/@<youtube_id>)
 zotero_username: # your zotero username
 

--- a/_data/cv.yml
+++ b/_data/cv.yml
@@ -1,14 +1,16 @@
 - title: General Information
   type: map
   contents:
-    - name: Name
-      value: Aakash Solanki
+    - name: Appointment
+      value: PhD Candidate, Anthropology & South Asian Studies, University of Toronto
     - name: Email
-      value: aakash.solanki@utoronto.ca
+      value: mail@aakashsolanki.net
     - name: Website
       value: https://aakashsolanki.net
+    - name: ORCID
+      value: 0000-0002-4879-6998
     - name: Research Areas
-      value: Anthropology of the state; digital governance; data infrastructures; critical data studies
+      value: Bureaucratic ethnography; colonial data infrastructures; digital governance; critical data studies
 
 - title: Education
   type: time_table
@@ -17,8 +19,8 @@
       institution: University of Toronto, Toronto, Canada
       year: 2019 – present
       description:
-        - Dissertation traces the colonial and postcolonial genealogies of statistical infrastructures in India.
-        - Methods span multi-sited ethnography, archival research, and collaborative digital humanities projects.
+        - Dissertation <em>The State's Ledgers</em> traces the archival and contemporary lives of statistical infrastructures in India.
+        - Methods span multi-sited ethnography, collaborative digital humanities work, and long-form archival research.
 
 - title: Research Projects
   type: time_table
@@ -27,39 +29,23 @@
       institution: University of Toronto
       year: 2022 – present
       description:
-        - Dissertation project following the material life of ledgers, punch cards, and databases in Indian bureaucracies.
-        - Documents how classificatory schemes migrate between colonial archives and contemporary digital governance pilots.
+        - Ethnographic and archival study of how ledgers, punch cards, and databases organize welfare and labour in Indian bureaucracies.
+        - Examines the afterlives of colonial classification systems inside contemporary digital governance pilots.
     - title: Civic Data Clinics
-      institution: Comparative analysis across U.S. and Indian public agencies
+      institution: Partnerships with public agencies in India and the United States
       year: 2016 – 2021
       description:
-        - Co-designed analytics toolkits to support equitable allocation decisions in education, health, and workforce programs.
-        - Built training modules that paired statistical modelling with qualitative stakeholder mapping for public servants.
+        - Co-designed analytics toolkits and participatory trainings to support equitable decision-making in education, health, and workforce programs.
+        - Built workflows that paired statistical models with qualitative field protocols for public servants.
 
-- title: Professional Experience
-  type: time_table
-  contents:
-    - title: Data & Evidence Consultant (Education Technology)
-      institution: Department of School Education, Government of Haryana, India
-      year: 2014 – 2016
-      description:
-        - Led ethnographic assessments that informed state-wide management information system deployments.
-        - Designed digital literacy workshops that increased adoption of new reporting workflows by frontline staff.
-    - title: Senior Data Scientist (Public Sector Innovation)
-      institution: Cross-jurisdictional government partnerships, United States & India
-      year: 2016 – 2019
-      description:
-        - Directed interdisciplinary teams delivering analytics products for municipal, state, and federal agencies.
-        - Embedded qualitative fieldwork protocols into predictive models to account for ethical and contextual risks.
-
-- title: Grants & Fellowships
+- title: Fellowships & Awards
   type: time_table
   contents:
     - title: Doctoral Research Award
       institution: International Development Research Centre (IDRC)
       year: 2023 – 2025
       description:
-        - Supports archival and ethnographic fieldwork on data infrastructures and social protection in India.
+        - Supports archival and ethnographic fieldwork on the social lives of state data infrastructures in India.
     - title: Dissertation Fieldwork Grant
       institution: Wenner-Gren Foundation for Anthropological Research
       year: 2022 – 2024
@@ -71,12 +57,28 @@
   contents:
     - title: Peer-reviewed scholarship
       items:
-        - '"Management of Performance and Performance of Management: Getting to Work On Time in the Indian bureaucracy," *South Asia: Journal of South Asian Studies* 42(3), 2019.'
-        - '"#GoingEthno in the Indian Bureaucracy," *Proceedings of Ethnographic Praxis in Industry Conference*, 2016 (with Sarvesh Tewari).'
-    - title: Public anthropology
+        - '“Management of Performance and Performance of Management: Getting to Work on Time in the Indian Bureaucracy,” <em>South Asia: Journal of South Asian Studies</em> 42(3), 2019.'
+        - '“#GoingEthno in the Indian Bureaucracy,” <em>Proceedings of the Ethnographic Praxis in Industry Conference</em>, 2016 (with Sarvesh Tewari).'
+    - title: Public anthropology & editorial work
       items:
-        - '"Suddenly, Statistics?" *Cultural Anthropology* Fieldsights, 2018.'
-        - '"Untidy Data: Spreadsheet practices in the Indian Bureaucracy," in *Lives of Data: Essays on Computational Cultures from India*, Institute of Network Cultures, 2020.'
+        - '“Suddenly, Statistics?” <em>Cultural Anthropology</em> Fieldsights, 2018.'
+        - '“Untidy Data: Spreadsheet practices in the Indian Bureaucracy,” in <em>Lives of Data: Essays on Computational Cultures from India</em>, Institute of Network Cultures, 2020.'
+
+- title: Professional Experience
+  type: time_table
+  contents:
+    - title: Data & Evidence Consultant (Education Technology)
+      institution: Department of School Education, Government of Haryana, India
+      year: 2014 – 2016
+      description:
+        - Led ethnographic assessments that informed statewide management information system deployments.
+        - Designed digital literacy workshops that increased adoption of new reporting workflows by frontline staff.
+    - title: Senior Data Scientist (Public Sector Innovation)
+      institution: Cross-jurisdictional government partnerships, United States & India
+      year: 2016 – 2019
+      description:
+        - Directed interdisciplinary teams delivering analytics products for municipal, state, and federal agencies.
+        - Embedded qualitative fieldwork protocols into predictive models to account for ethical and contextual risks.
 
 - title: Teaching & Mentorship
   type: list
@@ -87,14 +89,14 @@
 - title: Service & Leadership
   type: list
   contents:
-    - Contributing Editor, *Cultural Anthropology* (Fieldsights).
+    - Contributing Editor, <em>Cultural Anthropology</em> (Fieldsights).
     - Convenor, Development Seminar Series, University of Toronto.
-    - Organizer, collaborative reading group on South Asian data infrastructures across UTSC and Munk School communities.
+    - Organizer of a collaborative reading group on South Asian data infrastructures across UTSC and the Munk School.
 
 - title: Research & Technical Skills
   type: list
   contents:
     - Archival research, oral history, and long-form ethnography.
     - Quantitative analysis in R, Python, and SQL with emphasis on transparent, reproducible workflows.
-    - Data visualization and storytelling for public sector audiences.
+    - Data visualization and narrative design for public sector audiences.
     - Languages: English, Hindi.

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -18,27 +18,20 @@ selected_papers: true # includes a list of papers marked as "selected={true}"
 social: true # includes social icons at the bottom of the page
 ---
 
-Aakash Solanki is a [PhD candidate](https://www.anthropology.utoronto.ca/people/directories/graduate-students/aakash-solanki) in Anthropology and South Asian Studies at the University of Toronto. His scholarship follows a genealogical approach to states, statistics, and computing, tracing how data infrastructures shape governance and social life across South Asia.
+Aakash Solanki is a [PhD candidate](https://www.anthropology.utoronto.ca/people/directories/graduate-students/aakash-solanki) in Anthropology and South Asian Studies at the University of Toronto. He studies how bureaucratic infrastructures and classificatory regimes travel across colonial and postcolonial contexts, with a particular focus on South Asian data governance.
 
-His current projects examine the politics of information in colonial India alongside contemporary experiments with digital governance. This work builds on professional experience in government agencies across the United States and India, where he led data science initiatives in education, health, and workforce development.
+His dissertation, <em>The State's Ledgers</em>, follows the materials and methods that stitch together archival ledgers, punch-card systems, and contemporary databases in Indian bureaucracies. The project draws on multi-sited ethnography, collaborative digital humanities work, and extended archival research to trace how categories of welfare, labor, and citizenship are produced and contested.
 
-Research interests include:
+Before graduate school, Aakash led analytics and service-design initiatives for government partners in India and the United States. Those collaborations inform his current interest in how quantitative systems intersect with everyday administrative practices and the ethics of digital experimentation in public agencies.
 
-- Bureaucratic archives, enumeration, and classification
-- Digital statecraft and the ethics of data-driven decision-making
-- Collaborative, mixed-methods approaches for anthropological research
+Research areas include:
 
-His research program is supported by the International Development Research Centre (IDRC) and the Wenner-Gren Foundation for Anthropological Research. He has published in *South Asia* and serves as a Contributing Editor for *Cultural Anthropology*. Beyond the university, he convenes an interdisciplinary [Development Seminar Series](http://aakashsolanki.net/utdevsem.html) at the University of Toronto that links scholars, practitioners, and policymakers.
+- Colonial and postcolonial histories of statistics and statecraft
+- Design, deployment, and maintenance of data infrastructures
+- Mixed-method and collaborative approaches to studying governance technologies
 
-He keeps running reflections, archival finds, and teaching experiments on the [Fieldnotes blog](/blog/) and shares project updates, syllabi, and public writing there as they emerge. For a fuller overview of ongoing collaborations and service, see the refreshed [publications](/publications/) and [CV](/cv/) pages, or get in touch via the channels below.
+His fieldwork and writing are supported by the International Development Research Centre and the Wenner-Gren Foundation. He has published in *South Asia: Journal of South Asian Studies*, contributed to *Cultural Anthropology* Fieldsights, and co-led the University of Toronto's Development Seminar Series linking scholars, practitioners, and policymakers.
 
-
-<!--- Write your biography here. Tell the world about yourself. Link to your favorite [subreddit](http://reddit.com). You can put a picture in, too. The code is already in, just name your picture `prof_pic.jpg` and put it in the `img/` folder.
-
-Put your address / P.O. box / other info right below your picture. You can also disable any of these elements by editing `profile` property of the YAML header of your `_pages/about.md`. Edit `_bibliography/papers.bib` and Jekyll will render your [publications page](/al-folio/publications/) automatically.
-
-Link to your social media connections, too. This theme is set up to use [Font Awesome icons](https://fontawesome.com/) and [Academicons](https://jpswalsh.github.io/academicons/), like the ones below. Add your Facebook, Twitter, LinkedIn, Google Scholar, or just disable all of them.
-
--->
+Recent syllabi, project updates, and public writing live on the [Fieldnotes blog](/blog/). For a fuller overview of ongoing collaborations, awards, and teaching, explore the [publications](/publications/) and [CV](/cv/) pages or reach out through the links below.
 
 


### PR DESCRIPTION
## Summary
- point the site configuration at aakashsolanki.net and update profile metadata
- rewrite the homepage biography to reflect the latest dissertation, research areas, and collaborations
- replace the CV data with the new structure and ship the CNAME needed for the custom domain

## Testing
- bundle exec jekyll build

------
https://chatgpt.com/codex/tasks/task_e_6909d21753ec83308654c6430d4a6f71