### PR TITLE
Add Projects index page

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -32,7 +32,7 @@
             <li><a href="{{ '/publications/' | relative_url }}"><strong>Publications</strong></a></li>
             <li><a href="{{ '/teaching/' | relative_url }}"><strong>Teaching</strong></a></li>
             <li><a href="{{ '/talks/' | relative_url }}"><strong>Talks</strong></a></li>
-            <li><a href="{{ '/caste-technoscience/' | relative_url }}"><strong>Caste as/of Technoscience</strong></a></li>
+            <li><a href="{{ '/projects/' | relative_url }}"><strong>Projects</strong></a></li>
             <li><a href="{{ '/blog/' | relative_url }}"><strong>Blog</strong></a></li>
             <li><a href="https://orcid.org/0000-0002-4879-6998" target="_blank" rel="noopener noreferrer"><strong>ORCID</strong></a></li>
           </ul>

--- a/projects.md
+++ b/projects.md
@@ -1,0 +1,25 @@
+---
+layout: default
+title: Projects
+permalink: /projects/
+---
+
+## Projects
+
+* * *
+
+Ongoing intellectual and public-facing projects, sitting alongside the dissertation.
+
+* * *
+
+### [Caste as/of Technoscience](/caste-technoscience/)
+
+A collaborative project with Dr. Palashi Vaghela (Canada Research Chair, Simon Fraser University) convening interdisciplinary conversations at the Society for Social Studies of Science (4S) since 2021. The project reframes caste not as an identity category layered onto technoscience but as a sociotechnical formation in its own right.
+
+* * *
+
+### [India Library Spend Tracker](/freelibraries4all/)
+
+An interactive dashboard tracking public library spending across Indian states (2014–21), benchmarked against international peers. Examines the paradox of library legislation without library funding, the concentration of central grants, and the slow return of libraries to parliamentary attention. Developed as part of ongoing advocacy and research with the Free Libraries Network, India and South Asia.
+
+* * *


### PR DESCRIPTION
Introduces /projects/ as the home for ongoing intellectual and public-facing work.