### PR TITLE
Editorial redesign: typography-first, accessible, SEO-rich

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,50 +1,112 @@
 <!DOCTYPE html>
-<html lang="{{ site.lang | default: "en-US" }}">
+<html lang="{{ site.lang | default: "en-US" }}" data-theme="light">
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <!-- Set theme before CSS loads to prevent flash -->
+
     <script>
       (function () {
-        var stored = localStorage.getItem('theme');
-        var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        var stored;
+        try { stored = localStorage.getItem('theme'); } catch (e) {}
+        var prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
         document.documentElement.setAttribute('data-theme', stored || (prefersDark ? 'dark' : 'light'));
       })();
     </script>
-{% seo %}
+
+    {% seo %}
+
+    {%- assign title = page.title | default: site.title -%}
+    <meta name="description" content="{{ page.description | default: site.description | strip_newlines }}">
+    <meta name="author" content="{{ site.author }}">
+    <meta name="keywords" content="Aakash Solanki, anthropology, South Asian studies, ethnography, bureaucracy, India, statistics, computing, University of Toronto, STS, digital infrastructures, caste, technoscience">
+    <link rel="canonical" href="{{ page.url | absolute_url }}">
+    <meta name="robots" content="index,follow,max-image-preview:large">
+    <meta name="theme-color" content="#f7f2e8" media="(prefers-color-scheme: light)">
+    <meta name="theme-color" content="#2a251f" media="(prefers-color-scheme: dark)">
+
+    <meta name="citation_author" content="Solanki, Aakash">
+    <meta name="citation_author_institution" content="University of Toronto">
+    <meta name="citation_author_orcid" content="{{ site.orcid }}">
+    <meta name="DC.title" content="{{ title }} — {{ site.author }}">
+    <meta name="DC.creator" content="{{ site.author }}">
+    <meta name="DC.subject" content="Anthropology; Science and Technology Studies; South Asian Studies">
+    <meta name="DC.type" content="Text.Homepage.Personal">
+    <meta name="DC.language" content="en">
+
+    <meta property="og:type" content="profile">
+    <meta property="og:site_name" content="{{ site.author }}">
+    <meta property="og:title" content="{{ title }}">
+    <meta property="og:description" content="{{ page.description | default: site.description | strip_newlines }}">
+    <meta property="og:url" content="{{ page.url | absolute_url }}">
+    <meta property="og:locale" content="en_US">
+    <meta property="profile:first_name" content="Aakash">
+    <meta property="profile:last_name" content="Solanki">
+
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="{{ title }}">
+    <meta name="twitter:description" content="{{ page.description | default: site.description | strip_newlines }}">
+
+    {% if page.url == '/' %}
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Person",
+      "name": "{{ site.author }}",
+      "url": "{{ site.url }}",
+      "jobTitle": "PhD Candidate",
+      "affiliation": {
+        "@type": "CollegeOrUniversity",
+        "name": "University of Toronto",
+        "department": "Department of Anthropology; Centre for South Asian Studies"
+      },
+      "alumniOf": ["University of Toronto", "University of Chicago"],
+      "sameAs": ["{{ site.orcid }}", "https://scholar.google.com/citations?user=Y0LLLUMAAAAJ"],
+      "identifier": "{{ site.orcid }}",
+      "knowsAbout": [
+        "Anthropology of the state",
+        "Science and technology studies",
+        "History of statistics and computing",
+        "Ethnography of bureaucracy",
+        "South Asia",
+        "Caste and technoscience"
+      ]
+    }
+    </script>
+    {% endif %}
+
     <link rel="icon" href="{{ '/assets/img/favicon.svg' | relative_url }}" type="image/svg+xml">
-    <link rel="stylesheet" href="{{ "/assets/css/style.css" | relative_url }}">
+    <link rel="preconnect" href="https://fonts.bunny.net" crossorigin>
+    <link rel="stylesheet" href="https://fonts.bunny.net/css?family=newsreader:400,400i,500,500i,600|inter:400,500,600|jetbrains-mono:400,500&display=swap">
+    <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">
   </head>
   <body>
+    <a href="#main" class="skip-link">Skip to content</a>
+
     <div class="wrapper">
-      <header>
-        <h1><a href="{{ "/" | absolute_url }}">{{ site.title | default: site.github.repository_name }}</a></h1>
-
-        {% if site.logo %}
-          <img src="{{ site.logo | relative_url }}" alt="{{ site.title }}" />
-        {% endif %}
-
-        <p>{{ site.description | default: site.github.project_tagline }}</p>
-
-        <nav aria-label="Main">
-          <ul class="downloads">
-            <li><a href="{{ '/' | relative_url }}"><strong>About</strong></a></li>
-            <li><a href="{{ '/stuff/' | relative_url }}"><strong>Stuff</strong></a></li>
-            <li><a href="{{ '/contact/' | relative_url }}"><strong>Contact</strong></a></li>
-          </ul>
+      <header class="mast" role="banner">
+        <h1 class="mast-title">
+          <a href="{{ '/' | relative_url }}">{{ site.author }}</a>
+          <span class="sub">Toronto</span>
+        </h1>
+        <nav class="mast-nav" aria-label="Primary">
+          {%- assign here = page.url -%}
+          <a href="{{ '/' | relative_url }}"{% if here == '/' %} class="active" aria-current="page"{% endif %}>About</a>
+          <a href="{{ '/stuff/' | relative_url }}"{% if here contains '/stuff' %} class="active" aria-current="page"{% endif %}>Stuff</a>
+          <a href="{{ '/contact/' | relative_url }}"{% if here contains '/contact' %} class="active" aria-current="page"{% endif %}>Contact</a>
+          <button id="theme-toggle" type="button" aria-label="Toggle dark mode" title="Toggle dark mode">Dark</button>
         </nav>
-
-        <button id="theme-toggle" aria-label="Toggle dark mode" title="Toggle dark mode"></button>
       </header>
-      <section>
 
-      {{ content }}
+      <main id="main">
+        {{ content }}
+      </main>
 
-      </section>
-      <footer>
-        <p><small>Hosted on GitHub Pages &mdash; Theme by <a href="https://github.com/orderedlist">orderedlist</a></small></p>
+      <footer class="site">
+        <span>© {{ site.time | date: '%Y' }} {{ site.author }} · Set in Newsreader &amp; Inter</span>
+        <span><a href="{{ site.orcid }}" rel="noopener">ORCID</a> · <a href="{{ '/feed.xml' | relative_url }}">RSS</a></span>
       </footer>
     </div>
-    <script src="{{ "/assets/js/theme.js" | relative_url }}"></script>
+
+    <script src="{{ '/assets/js/theme.js' | relative_url }}" defer></script>
   </body>
 </html>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -2,15 +2,17 @@
 layout: default
 ---
 
-<small class="post-meta">{{ page.date | date: "%-d %B %Y" }}</small>
-<h1>{{ page.title }}</h1>
+<article class="prose">
+  <span class="post-meta">{{ page.date | date: "%-d %B %Y" }}</span>
+  <h1 class="post-title">{{ page.title }}</h1>
 
-{% if page.tags.size > 0 %}
-<p class="post-tags">
-  {% for tag in page.tags %}<a href="{{ '/tag/' | append: tag | relative_url }}">#{{ tag }}</a> {% endfor %}
-</p>
-{% endif %}
+  {% if page.tags.size > 0 %}
+  <p class="post-tags">
+    {% for tag in page.tags %}<a href="{{ '/tag/' | append: tag | relative_url }}">#{{ tag }}</a> {% endfor %}
+  </p>
+  {% endif %}
 
-{{ content }}
+  {{ content }}
 
-<p class="post-back"><a href="{{ '/blog' | relative_url }}">← All posts</a></p>
+  <p class="post-back"><a href="{{ '/blog/' | relative_url }}">← All posts</a></p>
+</article>

--- a/_layouts/tag.html
+++ b/_layouts/tag.html
@@ -2,19 +2,23 @@
 layout: default
 ---
 
-## #{{ page.tag }}
-
-* * *
+<header class="pagehead">
+  <div>
+    <div class="kicker">Tag</div>
+    <h1>#{{ page.tag }}</h1>
+    <p class="standfirst">Posts tagged <em>{{ page.tag }}</em>.</p>
+  </div>
+</header>
 
 <ul class="posts">
   {% for post in site.posts %}
-  {% if post.tags contains page.tag %}
-  <li>
-    <span class="post-date">{{ post.date | date: "%-d %B %Y" }}</span>
-    <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
-  </li>
-  {% endif %}
+    {% if post.tags contains page.tag %}
+    <li>
+      <span class="post-date">{{ post.date | date: "%-d %b %Y" }}</span>
+      <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
+    </li>
+    {% endif %}
   {% endfor %}
 </ul>
 
-<p class="post-back"><a href="{{ '/blog' | relative_url }}">← All posts</a></p>
+<p class="back"><a href="{{ '/blog/' | relative_url }}">← All posts</a></p>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,431 +1,661 @@
-@font-face { font-family: 'Noto Sans'; font-weight: 400; font-style: normal; src: url("../fonts/Noto-Sans-regular/Noto-Sans-regular.eot"); src: url("../fonts/Noto-Sans-regular/Noto-Sans-regular.eot?#iefix") format("embedded-opentype"), local("Noto Sans"), local("Noto-Sans-regular"), url("../fonts/Noto-Sans-regular/Noto-Sans-regular.woff2") format("woff2"), url("../fonts/Noto-Sans-regular/Noto-Sans-regular.woff") format("woff"), url("../fonts/Noto-Sans-regular/Noto-Sans-regular.ttf") format("truetype"), url("../fonts/Noto-Sans-regular/Noto-Sans-regular.svg#NotoSans") format("svg"); }
-@font-face { font-family: 'Noto Sans'; font-weight: 700; font-style: normal; src: url("../fonts/Noto-Sans-700/Noto-Sans-700.eot"); src: url("../fonts/Noto-Sans-700/Noto-Sans-700.eot?#iefix") format("embedded-opentype"), local("Noto Sans Bold"), local("Noto-Sans-700"), url("../fonts/Noto-Sans-700/Noto-Sans-700.woff2") format("woff2"), url("../fonts/Noto-Sans-700/Noto-Sans-700.woff") format("woff"), url("../fonts/Noto-Sans-700/Noto-Sans-700.ttf") format("truetype"), url("../fonts/Noto-Sans-700/Noto-Sans-700.svg#NotoSans") format("svg"); }
-@font-face { font-family: 'Noto Sans'; font-weight: 400; font-style: italic; src: url("../fonts/Noto-Sans-italic/Noto-Sans-italic.eot"); src: url("../fonts/Noto-Sans-italic/Noto-Sans-italic.eot?#iefix") format("embedded-opentype"), local("Noto Sans Italic"), local("Noto-Sans-italic"), url("../fonts/Noto-Sans-italic/Noto-Sans-italic.woff2") format("woff2"), url("../fonts/Noto-Sans-italic/Noto-Sans-italic.woff") format("woff"), url("../fonts/Noto-Sans-italic/Noto-Sans-italic.ttf") format("truetype"), url("../fonts/Noto-Sans-italic/Noto-Sans-italic.svg#NotoSans") format("svg"); }
-@font-face { font-family: 'Noto Sans'; font-weight: 700; font-style: italic; src: url("../fonts/Noto-Sans-700italic/Noto-Sans-700italic.eot"); src: url("../fonts/Noto-Sans-700italic/Noto-Sans-700italic.eot?#iefix") format("embedded-opentype"), local("Noto Sans Bold Italic"), local("Noto-Sans-700italic"), url("../fonts/Noto-Sans-700italic/Noto-Sans-700italic.woff2") format("woff2"), url("../fonts/Noto-Sans-700italic/Noto-Sans-700italic.woff") format("woff"), url("../fonts/Noto-Sans-700italic/Noto-Sans-700italic.ttf") format("truetype"), url("../fonts/Noto-Sans-700italic/Noto-Sans-700italic.svg#NotoSans") format("svg"); }
-
-/* ─── Theme variables ──────────────────────────────────────────────────────── */
-
+/* ── Tokens ───────────────────────────────────────────────── */
 :root {
-  --bg:                 #fff;
-  --text:               #4a4a4a;
-  --h1:                 #222;
-  --h2:                 #333;
-  --h3:                 #444;
-  --link:               #267CB9;
-  --link-hover:         #1a5a8a;
-  --border:             #e5e5e5;
-  --blockquote-border:  #267CB9;
-  --blockquote-bg:      #f9fbfd;
-  --blockquote-text:    #666;
-  --nav-bg:             #f7f7f7;
-  --nav-border:         #ddd;
-  --nav-text:           #555;
-  --nav-strong:         #222;
-  --nav-hover-bg:       #eef4fa;
-  --nav-hover-text:     #267CB9;
-  --nav-active-bg:      #ddeaf5;
-  --code-bg:            #f8f8f8;
-  --code-border:        #e5e5e5;
-  --code-text:          #333;
-  --footer-text:        #999;
-  --footer-link:        #999;
-  --tag-bg:             #eef4fa;
-  --tag-text:           #267CB9;
-  --tag-hover-bg:       #267CB9;
-  --tag-hover-text:     #fff;
-  --post-date:          #999;
-  --toggle-border:      #ddd;
-  --toggle-text:        #555;
-  --toggle-hover-bg:    #eef4fa;
+  --paper:    oklch(0.975 0.008 85);
+  --paper-2:  oklch(0.955 0.010 82);
+  --paper-3:  oklch(0.925 0.012 80);
+  --ink:      oklch(0.185 0.012 55);
+  --ink-2:    oklch(0.35  0.010 60);
+  --ink-3:    oklch(0.55  0.008 65);
+  --rule:     oklch(0.85  0.010 75);
+  --accent:   oklch(0.52  0.11  55);
+  --accent-2: oklch(0.72  0.09  55);
+  --highlight:oklch(0.94  0.06  92);
+
+  --serif: "Newsreader", Georgia, serif;
+  --sans:  "Inter", system-ui, -apple-system, sans-serif;
+  --mono:  "JetBrains Mono", ui-monospace, Menlo, monospace;
+
+  --fs-display: clamp(44px, 6.5vw, 84px);
+  --fs-title:   clamp(32px, 4.5vw, 52px);
+  --fs-body:    17px;
+
+  --ease: cubic-bezier(0.2, 0.6, 0.2, 1);
 }
 
 [data-theme="dark"] {
-  --bg:                 #1a1a1a;
-  --text:               #c8c8c8;
-  --h1:                 #e2e2e2;
-  --h2:                 #d6d6d6;
-  --h3:                 #cacaca;
-  --link:               #6ab3d9;
-  --link-hover:         #8ecbec;
-  --border:             #2e2e2e;
-  --blockquote-border:  #6ab3d9;
-  --blockquote-bg:      #212121;
-  --blockquote-text:    #aaa;
-  --nav-bg:             #242424;
-  --nav-border:         #333;
-  --nav-text:           #aaa;
-  --nav-strong:         #d0d0d0;
-  --nav-hover-bg:       #1d3346;
-  --nav-hover-text:     #6ab3d9;
-  --nav-active-bg:      #182d40;
-  --code-bg:            #212121;
-  --code-border:        #333;
-  --code-text:          #c8c8c8;
-  --footer-text:        #555;
-  --footer-link:        #555;
-  --tag-bg:             #1a3048;
-  --tag-text:           #6ab3d9;
-  --tag-hover-bg:       #6ab3d9;
-  --tag-hover-text:     #1a1a1a;
-  --post-date:          #777;
-  --toggle-border:      #444;
-  --toggle-text:        #aaa;
-  --toggle-hover-bg:    #1d3346;
+  --paper:    oklch(0.16 0.010 60);
+  --paper-2:  oklch(0.19 0.012 60);
+  --paper-3:  oklch(0.23 0.012 60);
+  --ink:      oklch(0.95 0.008 80);
+  --ink-2:    oklch(0.78 0.008 80);
+  --ink-3:    oklch(0.60 0.008 70);
+  --rule:     oklch(0.32 0.010 60);
+  --accent:   oklch(0.72 0.12 60);
+  --accent-2: oklch(0.62 0.10 60);
+  --highlight:oklch(0.32 0.05 80);
 }
 
-/* ─── Smooth transition on toggle click only ──────────────────────────────── */
-
-body.theme-transitioning,
-body.theme-transitioning * {
-  transition: background-color 0.25s ease, color 0.25s ease,
-              border-color 0.25s ease, fill 0.25s ease !important;
-}
-
-/* ─── Syntax highlighting ─────────────────────────────────────────────────── */
-
-.highlight table td { padding: 5px; }
-.highlight table pre { margin: 0; }
-.highlight .cm { color: #999988; font-style: italic; }
-.highlight .cp { color: #999999; font-weight: bold; }
-.highlight .c1 { color: #999988; font-style: italic; }
-.highlight .cs { color: #999999; font-weight: bold; font-style: italic; }
-.highlight .c, .highlight .cd { color: #999988; font-style: italic; }
-.highlight .err { color: #a61717; background-color: #e3d2d2; }
-.highlight .gd { color: #000000; background-color: #ffdddd; }
-.highlight .ge { color: #000000; font-style: italic; }
-.highlight .gr { color: #aa0000; }
-.highlight .gh { color: #999999; }
-.highlight .gi { color: #000000; background-color: #ddffdd; }
-.highlight .go { color: #888888; }
-.highlight .gp { color: #555555; }
-.highlight .gs { font-weight: bold; }
-.highlight .gu { color: #aaaaaa; }
-.highlight .gt { color: #aa0000; }
-.highlight .kc { color: #000000; font-weight: bold; }
-.highlight .kd { color: #000000; font-weight: bold; }
-.highlight .kn { color: #000000; font-weight: bold; }
-.highlight .kp { color: #000000; font-weight: bold; }
-.highlight .kr { color: #000000; font-weight: bold; }
-.highlight .kt { color: #445588; font-weight: bold; }
-.highlight .k, .highlight .kv { color: #000000; font-weight: bold; }
-.highlight .mf { color: #009999; }
-.highlight .mh { color: #009999; }
-.highlight .il { color: #009999; }
-.highlight .mi { color: #009999; }
-.highlight .mo { color: #009999; }
-.highlight .m, .highlight .mb, .highlight .mx { color: #009999; }
-.highlight .sb { color: #d14; }
-.highlight .sc { color: #d14; }
-.highlight .sd { color: #d14; }
-.highlight .s2 { color: #d14; }
-.highlight .se { color: #d14; }
-.highlight .sh { color: #d14; }
-.highlight .si { color: #d14; }
-.highlight .sx { color: #d14; }
-.highlight .sr { color: #009926; }
-.highlight .s1 { color: #d14; }
-.highlight .ss { color: #990073; }
-.highlight .s { color: #d14; }
-.highlight .na { color: #008080; }
-.highlight .bp { color: #999999; }
-.highlight .nb { color: #0086B3; }
-.highlight .nc { color: #445588; font-weight: bold; }
-.highlight .no { color: #008080; }
-.highlight .nd { color: #3c5d5d; font-weight: bold; }
-.highlight .ni { color: #800080; }
-.highlight .ne { color: #990000; font-weight: bold; }
-.highlight .nf { color: #990000; font-weight: bold; }
-.highlight .nl { color: #990000; font-weight: bold; }
-.highlight .nn { color: #555555; }
-.highlight .nt { color: #000080; }
-.highlight .vc { color: #008080; }
-.highlight .vg { color: #008080; }
-.highlight .vi { color: #008080; }
-.highlight .nv { color: #008080; }
-.highlight .ow { color: #000000; font-weight: bold; }
-.highlight .o { color: #000000; font-weight: bold; }
-.highlight .w { color: #bbbbbb; }
-.highlight { background-color: var(--code-bg); }
-
-/* ─── Base ────────────────────────────────────────────────────────────────── */
-
+/* ── Reset ────────────────────────────────────────────────── */
+*, *::before, *::after { box-sizing: border-box; }
+html { -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
 body {
-  background-color: var(--bg);
-  padding: 50px;
-  font: 16px/1.65 "Noto Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
-  color: var(--text);
-  font-weight: 400;
+  margin: 0;
+  font: 400 var(--fs-body)/1.6 var(--sans);
+  color: var(--ink);
+  background: var(--paper);
+  transition: background-color 0.25s var(--ease), color 0.25s var(--ease);
+}
+img { max-width: 100%; height: auto; display: block; }
+a { color: var(--ink); }
+
+:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+  border-radius: 2px;
 }
 
-h1, h2, h3, h4, h5, h6 { color: var(--h1); margin: 0 0 20px; }
-
-p, ul, ol, table, pre, dl { margin: 0 0 20px; }
-
-h1, h2, h3 { line-height: 1.1; }
-
-h1 { font-size: 26px; }
-
-h2 { color: var(--h2); }
-
-h3, h4, h5, h6 { color: var(--h3); }
-
-a { color: var(--link); text-decoration: none; }
-
-a:hover, a:focus { color: var(--link-hover); text-decoration: underline; }
-
-a small { font-size: 11px; color: var(--footer-text); margin-top: -0.3em; display: block; }
-
-a:hover small { color: var(--footer-text); }
-
-.wrapper { width: 860px; margin: 0 auto; }
-
-blockquote {
-  border-left: 3px solid var(--blockquote-border);
-  margin: 0 0 20px 0;
-  padding: 10px 0 10px 20px;
-  font-style: italic;
-  color: var(--blockquote-text);
-  background-color: var(--blockquote-bg);
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    transition-duration: 0.01ms !important;
+  }
 }
 
-code, pre {
-  font-family: Monaco, Bitstream Vera Sans Mono, Lucida Console, Terminal,
-    Consolas, Liberation Mono, DejaVu Sans Mono, Courier New, monospace;
-  color: var(--code-text);
+.sr-only {
+  position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+  overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0;
 }
 
-pre {
-  padding: 8px 15px;
-  background: var(--code-bg);
-  border-radius: 5px;
-  border: 1px solid var(--code-border);
-  overflow-x: auto;
-}
-
-table { width: 100%; border-collapse: collapse; }
-
-th, td { text-align: left; padding: 5px 10px; border-bottom: 1px solid var(--border); }
-
-dt { color: var(--h3); font-weight: 700; }
-
-th { color: var(--h3); }
-
-img { max-width: 100%; }
-
-strong { color: var(--h1); font-weight: 700; }
-
-small { font-size: 11px; }
-
-hr { border: 0; background: var(--border); height: 1px; margin: 0 0 20px; }
-
-/* ─── Sidebar header ──────────────────────────────────────────────────────── */
-
-header {
-  width: 270px;
-  float: left;
-  position: fixed;
-  -webkit-font-smoothing: subpixel-antialiased;
-}
-
-header ul {
-  list-style: none;
-  display: flex;
-  padding: 0;
-  margin: 0 0 10px;
-  background: var(--nav-bg);
-  border-radius: 5px;
-  border: 1px solid var(--nav-border);
-  width: 270px;
-  overflow: hidden;
-}
-
-header li {
-  flex: 1;
-  border-right: 1px solid var(--nav-border);
-}
-
-header li:first-child a { border-radius: 5px 0 0 5px; }
-header li:last-child a  { border-radius: 0 5px 5px 0; border-right: none; }
-
-header ul a {
-  line-height: 1;
-  font-size: 11px;
-  color: var(--nav-text);
-  display: block;
-  text-align: center;
-  padding: 7px 8px;
-  white-space: nowrap;
-}
-
-header ul a:hover, header ul a:focus {
-  color: var(--nav-hover-text);
+.skip-link {
+  position: absolute; top: -40px; left: 8px; z-index: 100;
+  background: var(--ink); color: var(--paper);
+  padding: 8px 12px; border-radius: 4px;
+  font: 500 13px/1 var(--sans);
   text-decoration: none;
-  background-color: var(--nav-hover-bg);
+}
+.skip-link:focus { top: 8px; }
+
+/* ── Wrapper + masthead ───────────────────────────────────── */
+.wrapper { max-width: 1240px; margin: 0 auto; }
+
+.mast {
+  padding: 32px max(24px, 5vw) 18px;
+  display: flex; justify-content: space-between;
+  align-items: baseline; gap: 32px;
+  border-bottom: 1px solid var(--ink);
+  flex-wrap: wrap; row-gap: 16px;
+}
+.mast-title {
+  font: 500 italic 22px/1 var(--serif);
+  letter-spacing: -0.01em;
+  margin: 0; flex-shrink: 0;
+}
+.mast-title a { color: var(--ink); text-decoration: none; }
+.mast-title .sub {
+  font: 400 11px/1 var(--sans);
+  letter-spacing: 0.12em; text-transform: uppercase;
+  color: var(--ink-3); font-style: normal;
+  margin-left: 14px; padding-left: 14px;
+  border-left: 1px solid var(--rule);
 }
 
-header ul a:active { background-color: var(--nav-active-bg); }
-
-header ul a strong { font-size: 13px; display: block; color: var(--nav-strong); }
-
-/* ─── Theme toggle button ─────────────────────────────────────────────────── */
+.mast-nav {
+  display: flex; gap: 28px; align-items: baseline;
+  font: 500 13px/1 var(--sans);
+  margin-left: auto; flex-wrap: wrap;
+}
+.mast-nav a {
+  color: var(--ink-2); text-decoration: none;
+  padding: 4px 0; position: relative;
+  transition: color 0.15s var(--ease);
+}
+.mast-nav a:hover { color: var(--ink); }
+.mast-nav a.active { color: var(--ink); }
+.mast-nav a.active::after {
+  content: ''; position: absolute;
+  left: 0; right: 0; bottom: -19px;
+  height: 2px; background: var(--accent);
+}
 
 #theme-toggle {
   background: none;
-  border: 1px solid var(--toggle-border);
-  border-radius: 4px;
-  color: var(--toggle-text);
+  border: 1px solid var(--rule);
+  color: var(--ink-3);
+  padding: 5px 10px; border-radius: 3px;
+  font: 500 10px/1 var(--sans);
+  letter-spacing: 0.1em; text-transform: uppercase;
   cursor: pointer;
-  font-size: 13px;
-  padding: 3px 10px;
-  display: block;
+  transition: color 0.15s var(--ease), border-color 0.15s var(--ease);
+}
+#theme-toggle:hover { color: var(--ink); border-color: var(--ink); }
+
+/* ── Main ─────────────────────────────────────────────────── */
+main {
+  padding: 48px max(24px, 5vw) 80px;
+}
+
+main > h1:first-child,
+main > h2:first-child { margin-top: 0; }
+
+main p {
+  font: 400 var(--fs-body)/1.65 var(--serif);
+  color: var(--ink);
+  text-wrap: pretty;
+  margin: 0 0 1em;
+  max-width: 65ch;
+}
+main p a,
+main ul a,
+main ol a {
+  color: var(--ink);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  text-decoration-thickness: 1px;
+  text-decoration-color: var(--rule);
+  transition: color 0.15s var(--ease), text-decoration-color 0.15s var(--ease);
+}
+main p a:hover,
+main ul a:hover,
+main ol a:hover {
+  color: var(--accent);
+  text-decoration-color: var(--accent);
+}
+
+main h2, main h3, main h4 {
+  font-family: var(--serif);
+  color: var(--ink);
+}
+main h2 {
+  font: 400 italic 28px/1.2 var(--serif);
+  margin: 48px 0 20px;
+  letter-spacing: -0.01em;
+}
+main h3 {
+  font: 500 20px/1.3 var(--serif);
+  margin: 32px 0 12px;
+}
+main h4 {
+  font: 500 16px/1.3 var(--serif);
+  margin: 24px 0 8px;
+}
+
+main ul, main ol {
+  font-family: var(--serif);
+  font-size: var(--fs-body);
+  line-height: 1.65;
+  color: var(--ink);
+  max-width: 65ch;
+}
+main ul li, main ol li { margin-bottom: 8px; }
+
+main blockquote {
+  margin: 24px 0;
+  padding: 4px 0 4px 20px;
+  border-left: 2px solid var(--accent);
+  font: 400 italic 16px/1.6 var(--serif);
+  color: var(--ink-2);
+  max-width: 60ch;
+}
+
+main hr {
+  border: 0;
+  border-top: 1px solid var(--rule);
+  margin: 32px 0;
+}
+
+main code {
+  font: 400 14px/1.4 var(--mono);
+  background: var(--paper-3);
+  padding: 2px 6px; border-radius: 3px;
+}
+main pre {
+  background: var(--paper-3);
+  padding: 16px; border-radius: 4px;
+  overflow-x: auto;
+  font: 400 13px/1.5 var(--mono);
+}
+main pre code { background: none; padding: 0; }
+
+/* ── Home: hero / lede ────────────────────────────────────── */
+.lede {
+  display: grid;
+  grid-template-columns: 1fr 280px;
+  gap: 72px;
+  align-items: start;
+  padding-bottom: 48px;
+  border-bottom: 1px solid var(--rule);
+  margin-bottom: 8px;
+}
+.lede .kicker {
+  font: 500 11px/1 var(--sans);
+  letter-spacing: 0.18em; text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 20px;
+}
+.lede .hd {
+  font: 400 var(--fs-display)/0.98 var(--serif);
+  letter-spacing: -0.025em;
+  margin: 0 0 28px;
+  color: var(--ink);
+  text-wrap: balance;
+}
+.lede .hd em { font-style: italic; color: var(--accent); }
+.lede .standfirst {
+  font: 400 21px/1.5 var(--serif);
+  color: var(--ink-2);
+  text-wrap: pretty;
+  max-width: 48ch;
+  margin: 0;
+}
+.lede .portrait {
+  width: 100%;
+  aspect-ratio: 4/5;
+  background: var(--paper-3);
+  overflow: hidden;
+  border-radius: 2px;
+}
+.lede .portrait img {
+  width: 100%; height: 100%;
+  object-fit: cover;
+}
+.lede .portrait-cap {
+  font: 400 italic 12px/1.4 var(--serif);
+  color: var(--ink-3);
+  margin-top: 10px;
+  max-width: 28ch;
+}
+@media (max-width: 820px) {
+  .lede { grid-template-columns: 1fr; gap: 32px; }
+  .lede .portrait { max-width: 240px; }
+}
+
+/* ── Labeled content blocks (home) ────────────────────────── */
+.block {
+  display: grid;
+  grid-template-columns: 180px 1fr;
+  gap: 40px;
+  padding: 32px 0;
+  border-top: 1px solid var(--rule);
+}
+.block:last-of-type { border-bottom: 1px solid var(--rule); }
+.block .label {
+  font: 500 11px/1.3 var(--sans);
+  letter-spacing: 0.15em; text-transform: uppercase;
+  color: var(--ink-3);
+  padding-top: 4px;
+}
+.block .body { max-width: 65ch; }
+.block .body > :first-child { margin-top: 0; }
+.block .body > :last-child { margin-bottom: 0; }
+@media (max-width: 820px) {
+  .block { grid-template-columns: 1fr; gap: 12px; }
+}
+
+/* ── Bullet lists (home research, awards, news) ───────────── */
+.bullets { list-style: none; padding: 0; margin: 0; }
+.bullets li {
+  font: 400 17px/1.6 var(--serif);
+  color: var(--ink);
+  padding: 10px 0;
+  border-bottom: 1px solid var(--rule);
+  display: grid;
+  grid-template-columns: 48px 1fr;
+  gap: 16px;
+  align-items: baseline;
+  margin-bottom: 0;
+}
+.bullets li:last-child { border-bottom: 0; }
+.bullets li .num {
+  font: 400 12px/1 var(--mono);
+  color: var(--ink-3);
+  padding-top: 4px;
+  font-variant-numeric: tabular-nums;
+}
+.bullets.news li { grid-template-columns: 110px 1fr; }
+.bullets.news li .num {
+  font: 500 12px/1.4 var(--sans);
+  color: var(--accent);
+  letter-spacing: 0.05em; text-transform: uppercase;
+}
+
+/* ── Sub-page head ────────────────────────────────────────── */
+.pagehead {
+  display: grid;
+  grid-template-columns: 1fr 320px;
+  gap: 64px;
+  padding-bottom: 48px;
+  border-bottom: 1px solid var(--rule);
   margin-bottom: 16px;
 }
-
-#theme-toggle:hover {
-  border-color: var(--link);
-  color: var(--link);
-  background-color: var(--toggle-hover-bg);
+.pagehead .kicker {
+  font: 500 11px/1 var(--sans);
+  letter-spacing: 0.18em; text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 18px;
 }
-
-#theme-toggle::before           { content: "☀ light"; }
-[data-theme="dark"] #theme-toggle::before { content: "☽ dark"; }
-
-/* ─── Main content ────────────────────────────────────────────────────────── */
-
-section { width: 500px; float: right; padding-bottom: 50px; }
-
-/* ─── Footer ──────────────────────────────────────────────────────────────── */
-
-footer {
-  width: 270px;
-  float: left;
-  position: fixed;
-  bottom: 50px;
-  -webkit-font-smoothing: subpixel-antialiased;
-  font-size: 13px;
-  color: var(--footer-text);
-}
-
-footer p { margin: 0; }
-
-footer a { color: var(--footer-link); }
-footer a:hover { color: var(--link); text-decoration: none; }
-
-/* ─── Blog index ──────────────────────────────────────────────────────────── */
-
-ul.posts {
-  list-style: none;
-  padding: 0;
-  margin: 0 0 24px;
-}
-
-ul.posts li {
-  display: flex;
-  align-items: baseline;
-  gap: 12px;
-  padding: 6px 0;
-  border-bottom: 1px solid var(--border);
-}
-
-ul.posts li:last-child { border-bottom: none; }
-
-.post-date {
-  color: var(--post-date);
-  font-size: 13px;
-  white-space: nowrap;
-  min-width: 80px;
-}
-
-.posts-empty { color: var(--post-date); font-style: italic; }
-
-/* ─── News section ────────────────────────────────────────────────────────── */
-
-.news-list {
-  list-style: none;
-  padding: 0;
+.pagehead h1 {
+  font: 400 italic var(--fs-title)/1 var(--serif);
+  letter-spacing: -0.02em;
   margin: 0 0 20px;
+  color: var(--ink);
+  text-wrap: balance;
+}
+.pagehead .standfirst {
+  font: 400 17px/1.55 var(--serif);
+  color: var(--ink-2);
+  max-width: 52ch;
+  margin: 0;
+}
+.pagehead .meta dl {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px 16px;
+  margin: 0;
+  padding: 16px 0 0;
+  border-top: 1px solid var(--rule);
+}
+.pagehead .meta dt {
+  font: 500 10px/1 var(--sans);
+  letter-spacing: 0.1em; text-transform: uppercase;
+  color: var(--ink-3);
+}
+.pagehead .meta dd {
+  margin: 0;
+  color: var(--ink);
+  font: 500 14px/1.4 var(--sans);
+}
+@media (max-width: 820px) {
+  .pagehead { grid-template-columns: 1fr; gap: 24px; }
 }
 
-.news-list li {
-  display: flex;
-  gap: 16px;
-  padding: 8px 0;
-  border-bottom: 1px solid var(--border);
+/* ── Section heading within a sub-page ────────────────────── */
+.sect {
+  font: 500 italic 26px/1.2 var(--serif);
+  color: var(--ink);
+  margin: 56px 0 20px;
+  padding-bottom: 12px;
+  position: relative;
+}
+.sect:first-of-type { margin-top: 32px; }
+.sect .n {
+  display: block;
+  font: 400 11px/1 var(--mono);
+  font-style: normal;
+  color: var(--accent);
+  letter-spacing: 0.05em;
+  margin-bottom: 8px;
+}
+
+/* ── Publication entry ────────────────────────────────────── */
+.pub {
+  padding: 20px 0;
+  border-top: 1px solid var(--rule);
+  display: grid;
+  grid-template-columns: 80px 1fr auto;
+  gap: 24px;
   align-items: baseline;
 }
-
-.news-list li:last-child { border-bottom: none; }
-
-.news-date {
-  color: var(--post-date);
-  font-size: 13px;
+.pub:last-of-type { border-bottom: 1px solid var(--rule); }
+.pub .yr {
+  font: 500 13px/1.2 var(--mono);
+  color: var(--accent);
+  font-variant-numeric: tabular-nums;
+}
+.pub .main { max-width: 60ch; }
+.pub .main .title {
+  font: 400 18px/1.4 var(--serif);
+  color: var(--ink);
+  text-wrap: pretty;
+  margin: 0 0 4px;
+}
+.pub .main .title a { color: inherit; }
+.pub .main .venue {
+  font: 400 italic 14px/1.5 var(--serif);
+  color: var(--ink-2);
+  margin: 0;
+}
+.pub .main .note {
+  font: 400 13px/1.4 var(--sans);
+  color: var(--ink-3);
+  margin: 4px 0 0;
+}
+.pub .tags {
+  font: 400 11px/1 var(--sans);
+  color: var(--ink-3);
+  letter-spacing: 0.05em; text-transform: uppercase;
+  text-align: right;
   white-space: nowrap;
-  min-width: 90px;
+}
+@media (max-width: 820px) {
+  .pub { grid-template-columns: 1fr; gap: 8px; }
+  .pub .tags { text-align: left; }
 }
 
-/* ─── Post page ───────────────────────────────────────────────────────────── */
-
-.post-meta {
-  color: var(--post-date);
-  font-size: 14px;
+/* ── Course entry ─────────────────────────────────────────── */
+.course {
+  padding: 28px 0;
+  border-top: 1px solid var(--rule);
+  display: grid;
+  grid-template-columns: 200px 1fr 180px;
+  gap: 32px;
+  align-items: baseline;
+}
+.course:last-of-type { border-bottom: 1px solid var(--rule); }
+.course .role {
+  font: 500 11px/1.2 var(--sans);
+  letter-spacing: 0.12em; text-transform: uppercase;
+  color: var(--ink-3);
+}
+.course .title {
+  font: 500 19px/1.3 var(--serif);
+  color: var(--ink);
+  margin: 0 0 8px;
+}
+.course .desc {
+  font: 400 15px/1.55 var(--serif);
+  color: var(--ink-2);
+  margin: 0;
+  max-width: 60ch;
+}
+.course .when {
+  font: 400 13px/1.45 var(--sans);
+  color: var(--ink-3);
+  text-align: right;
+}
+.course .when .where {
+  color: var(--ink); font-weight: 500;
   display: block;
-  margin-bottom: 4px;
+}
+@media (max-width: 820px) {
+  .course { grid-template-columns: 1fr; gap: 10px; }
+  .course .when { text-align: left; }
+  .course .when .where { display: inline; }
 }
 
-.post-tags { margin: -8px 0 20px; }
+/* ── Talk entry ───────────────────────────────────────────── */
+.talk {
+  padding: 16px 0;
+  border-top: 1px solid var(--rule);
+  display: grid;
+  grid-template-columns: 100px 1fr auto;
+  gap: 24px;
+  align-items: baseline;
+}
+.talk:last-of-type { border-bottom: 1px solid var(--rule); }
+.talk .dt {
+  font: 500 12px/1.3 var(--sans);
+  color: var(--ink-3);
+  letter-spacing: 0.04em; text-transform: uppercase;
+}
+.talk .ttl {
+  font: 400 italic 17px/1.4 var(--serif);
+  color: var(--ink);
+}
+.talk .at {
+  font: 400 14px/1.4 var(--sans);
+  color: var(--ink-3);
+  text-align: right;
+}
+@media (max-width: 820px) {
+  .talk { grid-template-columns: 1fr; gap: 4px; }
+  .talk .at { text-align: left; }
+}
 
-.post-tags a {
+/* ── Project entry ────────────────────────────────────────── */
+.project {
+  padding: 28px 0;
+  border-top: 1px solid var(--rule);
+}
+.project:last-of-type { border-bottom: 1px solid var(--rule); }
+.project h2 {
+  font: 500 italic 24px/1.25 var(--serif);
+  color: var(--ink);
+  margin: 0 0 10px;
+}
+.project h2 a { color: inherit; }
+.project p {
+  font: 400 16px/1.6 var(--serif);
+  color: var(--ink-2);
+  margin: 0;
+  max-width: 60ch;
+}
+
+/* ── Blog post list ───────────────────────────────────────── */
+.posts { list-style: none; padding: 0; margin: 0; }
+.posts li {
+  padding: 24px 0;
+  border-top: 1px solid var(--rule);
+  display: grid;
+  grid-template-columns: 120px 1fr;
+  gap: 32px;
+  align-items: baseline;
+  margin-bottom: 0;
+}
+.posts li:last-child { border-bottom: 1px solid var(--rule); }
+.posts li .post-date {
+  font: 500 11px/1.2 var(--sans);
+  letter-spacing: 0.12em; text-transform: uppercase;
+  color: var(--ink-3);
+}
+.posts li a {
+  font: 400 20px/1.3 var(--serif);
+  color: var(--ink);
+  text-decoration: none;
+  letter-spacing: -0.01em;
+}
+.posts li a:hover { color: var(--accent); }
+
+.posts-empty {
+  font: 400 italic 16px/1.5 var(--serif);
+  color: var(--ink-3);
+}
+
+/* ── Contact links block ──────────────────────────────────── */
+.contact-links {
+  margin-top: 24px;
+  font: 400 15px/1.9 var(--sans);
+}
+.contact-links .row { margin: 0; }
+.contact-links .k {
   display: inline-block;
-  background: var(--tag-bg);
-  color: var(--tag-text);
-  padding: 2px 8px;
-  border-radius: 3px;
-  font-size: 12px;
-  margin-right: 4px;
+  width: 90px;
+  font: 500 11px/1 var(--sans);
+  letter-spacing: 0.1em; text-transform: uppercase;
+  color: var(--ink-3);
+  vertical-align: middle;
+}
+.contact-links a { color: var(--ink); }
+
+/* ── Stuff list ───────────────────────────────────────────── */
+.stuff-list { list-style: none; padding: 0; margin: 24px 0; max-width: 520px; }
+.stuff-list li {
+  border-top: 1px solid var(--rule);
+  padding: 18px 0;
+  margin-bottom: 0;
+}
+.stuff-list li:last-child { border-bottom: 1px solid var(--rule); }
+.stuff-list a {
+  font: 400 22px/1.3 var(--serif);
+  color: var(--ink);
+  text-decoration: none;
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 16px;
+}
+.stuff-list a:hover { color: var(--accent); }
+.stuff-list a::after {
+  content: '→';
+  color: var(--ink-3);
+  font: 400 18px/1 var(--sans);
+  transition: color 0.15s var(--ease), transform 0.15s var(--ease);
+}
+.stuff-list a:hover::after {
+  color: var(--accent);
+  transform: translateX(4px);
 }
 
-.post-tags a:hover {
-  background: var(--tag-hover-bg);
-  color: var(--tag-hover-text);
+/* ── Back link ────────────────────────────────────────────── */
+.back {
+  margin: 64px 0 0;
+  font: 500 11px/1 var(--sans);
+  letter-spacing: 0.12em; text-transform: uppercase;
+}
+.back a {
+  color: var(--ink-3);
   text-decoration: none;
 }
+.back a:hover { color: var(--accent); }
 
-.post-back {
-  margin-top: 40px;
-  padding-top: 20px;
-  border-top: 1px solid var(--border);
-  font-size: 14px;
+/* ── Post (single blog post) ──────────────────────────────── */
+.post-meta {
+  display: block;
+  font: 500 11px/1 var(--sans);
+  letter-spacing: 0.12em; text-transform: uppercase;
+  color: var(--ink-3);
+  margin-bottom: 16px;
 }
-
-/* ─── Responsive ──────────────────────────────────────────────────────────── */
-
-@media print, screen and (max-width: 960px) {
-  div.wrapper { width: auto; margin: 0; }
-  header, section, footer { float: none; position: static; width: auto; }
-  header { padding-right: 320px; }
-  section { border: 1px solid var(--border); border-width: 1px 0; padding: 20px 0; margin: 0 0 20px; }
-  header a small { display: inline; }
-  header ul { position: absolute; right: 50px; top: 52px; width: auto; height: auto; display: flex; }
-  header li { height: auto; }
-  header ul a { height: auto; padding: 8px 12px; }
-  #theme-toggle { position: absolute; right: 50px; top: 100px; margin: 0; }
+.post-title {
+  font: 400 italic var(--fs-title)/1 var(--serif);
+  color: var(--ink);
+  margin: 0 0 16px;
+  letter-spacing: -0.02em;
+  text-wrap: balance;
 }
-
-@media print, screen and (max-width: 720px) {
-  body { word-wrap: break-word; }
-  header { padding: 0; }
-  header ul, header p.view { position: static; }
-  pre, code { word-wrap: normal; }
-  #theme-toggle { position: static; margin: 8px 0 16px; }
+.post-tags {
+  font: 400 12px/1.4 var(--sans);
+  color: var(--ink-3);
+  margin: 0 0 32px;
 }
-
-@media print, screen and (max-width: 480px) {
-  body { padding: 15px; }
-  header ul { width: 100%; flex-wrap: wrap; height: auto; }
-  header li { flex: 1; }
+.post-tags a {
+  color: var(--ink-3);
+  text-decoration: none;
+  margin-right: 8px;
 }
+.post-tags a:hover { color: var(--accent); }
+.post-back { margin-top: 48px; font: 500 11px/1 var(--sans);
+  letter-spacing: 0.12em; text-transform: uppercase; }
+.post-back a { color: var(--ink-3); text-decoration: none; }
+.post-back a:hover { color: var(--accent); }
 
+/* ── Footer ───────────────────────────────────────────────── */
+footer.site {
+  padding: 32px max(24px, 5vw);
+  border-top: 1px solid var(--rule);
+  font: 400 12px/1.5 var(--sans);
+  color: var(--ink-3);
+  display: flex;
+  justify-content: space-between;
+  gap: 24px;
+  flex-wrap: wrap;
+}
+footer.site a { color: var(--ink-3); text-decoration: none; }
+footer.site a:hover { color: var(--accent); }
+
+/* ── Print ────────────────────────────────────────────────── */
 @media print {
-  body { padding: 0.4in; font-size: 12pt; color: #444; }
-  #theme-toggle { display: none; }
+  body { background: #fff; color: #000; font: 11pt/1.4 Georgia, serif; }
+  .mast-nav, #theme-toggle, footer.site, .skip-link, .back { display: none; }
+  .mast { border-color: #000; }
+  a { color: inherit; text-decoration: underline; }
 }

--- a/blog/index.html
+++ b/blog/index.html
@@ -1,20 +1,31 @@
 ---
 layout: default
 title: Blog
+description: "Short essays and notes, mostly on fieldwork, methods, and the small grammars of bureaucratic life."
 ---
 
-## Blog
-
-* * *
+<header class="pagehead">
+  <div>
+    <div class="kicker">Folio · Notebook</div>
+    <h1>Notebook.</h1>
+    <p class="standfirst">Short essays and notes, mostly on fieldwork, methods, and the small grammars of bureaucratic life. Cadence: occasional.</p>
+  </div>
+  <div class="meta">
+    <dl>
+      <dt>Posts</dt><dd>{{ site.posts.size }}</dd>
+      <dt>RSS</dt><dd><a href="{{ '/feed.xml' | relative_url }}">/feed.xml</a></dd>
+    </dl>
+  </div>
+</header>
 
 {% if site.posts.size > 0 %}
   {% assign postsByYear = site.posts | group_by_exp: "post", "post.date | date: '%Y'" %}
   {% for year in postsByYear %}
-  <h3>{{ year.name }}</h3>
+  <h2 class="sect"><span class="n">{{ year.name }}</span>Year {{ year.name }}</h2>
   <ul class="posts">
     {% for post in year.items %}
     <li>
-      <span class="post-date">{{ post.date | date: "%-d %B" }}</span>
+      <span class="post-date">{{ post.date | date: "%-d %b" }}</span>
       <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
     </li>
     {% endfor %}
@@ -23,3 +34,5 @@ title: Blog
 {% else %}
   <p class="posts-empty">No posts yet — check back soon.</p>
 {% endif %}
+
+<p class="back"><a href="/stuff/">← Back to Stuff</a></p>

--- a/caste-technoscience.md
+++ b/caste-technoscience.md
@@ -2,32 +2,40 @@
 layout: default
 title: Caste as/of Technoscience
 permalink: /caste-technoscience/
+description: "An ongoing collaborative project convening interdisciplinary conversations on caste and technoscience at the Society for Social Studies of Science (4S) since 2021."
 ---
 
-## Caste as/of Technoscience
+<header class="pagehead">
+  <div>
+    <div class="kicker">Project</div>
+    <h1>Caste as/of Technoscience.</h1>
+    <p class="standfirst">A collaborative, ongoing intellectual project convening interdisciplinary conversations at the Society for Social Studies of Science (4S) since 2021. Co-convened with Dr. Palashi Vaghela, Canada Research Chair at Simon Fraser University.</p>
+  </div>
+  <div class="meta">
+    <dl>
+      <dt>Since</dt><dd>2021</dd>
+      <dt>Venue</dt><dd>4S Conference</dd>
+      <dt>Co-convener</dt><dd>Palashi Vaghela</dd>
+      <dt>Output</dt><dd>Special issue (in progress)</dd>
+    </dl>
+  </div>
+</header>
 
-* * *
+<div class="block">
+  <div class="label">The question</div>
+  <div class="body">
+    <p>Despite its importance as an analytical category in the social life of South Asia and its diasporas, caste has remained relatively undertheorized in the social studies of science and technology. Where caste does appear in STS, it has most often figured as an identity category rather than as a sociotechnical formation in its own right.</p>
+    <p>This project asks: what happens when we reframe the study of caste <em>as</em> a study of technoscience? What conceptual and methodological toolkits does such a move require? How are caste and technoscience intertwined — historically, infrastructurally, materially? What does it mean to approach caste as a technoscientific project of domination and subjugation, or as a form of media that mediates sociotechnical relations?</p>
+  </div>
+</div>
 
-A collaborative, ongoing intellectual project convening interdisciplinary conversations at the Society for Social Studies of Science (4S) conferences since 2021. Co-convened with Dr. Palashi Vaghela, Canada Research Chair at Simon Fraser University.
+<div class="block">
+  <div class="label">Convenings</div>
+  <div class="body">
+    <p><strong>2021 · 4S (virtual) — <em>Caste as/of Technoscience</em>.</strong> A four-session open panel inaugurating sustained attention to caste as a generative analytical framework for STS. The panel drew together anthropologists, historians, media studies scholars, and information scientists working across empire, colonialism, and postcolonial technoscience. Conversations from this panel are taking shape as a journal special issue.</p>
+    <p><strong>2025 · 4S Seattle — <em>Caste as/of Technoscience II</em>.</strong> Advanced the 2021 work by identifying a limit within much critical scholarship: that the field often remains organized around opposition to Brahmin hegemony, which inadvertently keeps Brahminism at the center. The 2025 panel began the harder task of thinking both technoscience and caste <em>without</em> centering Brahminism at all.</p>
+    <p><strong>Forthcoming — <em>Caste as/of Technoscience III</em>.</strong> The next convening continues the trajectory of the series. More soon.</p>
+  </div>
+</div>
 
-* * *
-
-### The question
-
-Despite its importance as an analytical category in the social life of South Asia and its diasporas, caste has remained relatively undertheorized in the social studies of science and technology. Where caste does appear in STS, it has most often figured as an identity category rather than as a sociotechnical formation in its own right.
-
-This project asks: what happens when we reframe the study of caste *as* a study of technoscience? What conceptual and methodological toolkits does such a move require? How are caste and technoscience intertwined — historically, infrastructurally, materially? What does it mean to approach caste as a technoscientific project of domination and subjugation, or as a form of media that mediates sociotechnical relations?
-
-* * *
-
-### Convenings
-
-**2021 · 4S (virtual) — *Caste as/of Technoscience*.** A four-session open panel inaugurating sustained attention to caste as a generative analytical framework for STS. The panel drew together anthropologists, historians, media studies scholars, and information scientists working across empire, colonialism, and postcolonial technoscience. Conversations from this panel are taking shape as a journal special issue.
-
-**2025 · 4S Seattle — *Caste as/of Technoscience II*.** Advanced the 2021 work by identifying a limit within much critical scholarship: that the field often remains organized around opposition to Brahmin hegemony, which inadvertently keeps Brahminism at the center. The 2025 panel began the harder task of thinking both technoscience and caste *without* centering Brahminism at all.
-
-**Forthcoming — *Caste as/of Technoscience III*.** The next convening continues the trajectory of the series. More soon.
-
-* * *
-
-[← Back to Projects](/projects/)
+<p class="back"><a href="/projects/">← Back to Projects</a></p>

--- a/contact.md
+++ b/contact.md
@@ -2,20 +2,27 @@
 layout: default
 title: Contact
 permalink: /contact/
+description: "Get in touch with Aakash Solanki — email, ORCID, Google Scholar."
 ---
 
-## Contact
+<header class="pagehead">
+  <div>
+    <div class="kicker">Correspondence</div>
+    <h1>Say hello.</h1>
+    <p class="standfirst">Other earlier-career researchers and students working on questions of the state, technology, caste, or development are especially welcome to write. I&rsquo;m keen to support folks finding their way into research or academia without the social capital that usually opens those doors — even as I&rsquo;m still finding my own way.</p>
+  </div>
+  <div class="meta">
+    <dl>
+      <dt>Based in</dt><dd>Toronto</dd>
+      <dt>Response</dt><dd>A few days</dd>
+    </dl>
+  </div>
+</header>
 
-* * *
+<div class="contact-links">
+  <div class="row"><span class="k">Email</span> mail at aakashsolanki dot net</div>
+  <div class="row"><span class="k">ORCID</span> <a href="https://orcid.org/0000-0002-4879-6998" rel="noopener">0000-0002-4879-6998</a></div>
+  <div class="row"><span class="k">Scholar</span> <a href="https://scholar.google.com/citations?user=Y0LLLUMAAAAJ" rel="noopener">Google Scholar</a></div>
+</div>
 
-Email — mail at aakashsolanki dot net
-
-Find me also on [ORCID](https://orcid.org/0000-0002-4879-6998) and [Google Scholar](https://scholar.google.com/citations?user=Y0LLLUMAAAAJ).
-
-* * *
-
-Other earlier career researchers and students working on questions of the state, technology, caste, or development are especially welcome to write. I'm keen to support folks finding their way into research or academia without the social capital that usually opens those doors — even as I'm still finding my own way.
-
-* * *
-
-[← Back to About](/)
+<p class="back"><a href="/">← Back to About</a></p>

--- a/index.md
+++ b/index.md
@@ -1,71 +1,62 @@
 ---
 layout: default
+description: "Aakash Solanki is a PhD candidate in Anthropology and South Asian Studies at the University of Toronto. His research sits at the intersection of the anthropology of the state, science and technology studies, and the historical study of statistics and computing."
 ---
 
-## About
+<section class="lede" aria-labelledby="home-hd">
+  <div>
+    <div class="kicker">Aakash Solanki · Spring 2026</div>
+    <p class="hd" id="home-hd">An anthropology of <em>states, statistics,</em> and the machines that count them.</p>
+    <p class="standfirst">PhD candidate in Anthropology and South Asian Studies at the University of Toronto. Research on bureaucracy, data infrastructures, and the technopolitics of the Indian state.</p>
+  </div>
+  <div>
+    <div class="portrait">
+      {% if site.logo %}<img src="{{ site.logo | relative_url }}" alt="Portrait of Aakash Solanki" loading="lazy">{% endif %}
+    </div>
+  </div>
+</section>
 
-* * *
+<div class="block">
+  <div class="label">I. Biography</div>
+  <div class="body">
+    <p>Aakash Solanki is a PhD candidate in Anthropology and South Asian Studies at the University of Toronto. His research sits at the intersection of the anthropology of the state, science and technology studies, and the historical study of statistics and computing. He has worked on the collection, classification, and management of information in colonial and postcolonial India. In addition to prior training in computer science, he has worked in government agencies in the US and India on data science projects in education, health, and skill development at municipal, state, and federal levels.</p>
+    <p>His dissertation, <em>Governing Indeterminately: An Ethnography of Technopopulism from India</em>, draws on long-term fieldwork in Indian state and central bureaucracies to examine how digital infrastructures mediate development, statecraft, and fiscal federal relations. The research is funded by the International Development Research Centre (IDRC) and the Wenner-Gren Foundation for Anthropological Research.</p>
+    <p>He has previously published in <em>South Asia: Journal of South Asian Studies</em> and is a former Student Editor at <em>Cultural Anthropology</em>. He convened the interdisciplinary <a href="/utdevsem/">Development Seminar</a> at the University of Toronto.</p>
+  </div>
+</div>
 
-Aakash Solanki is a PhD candidate in Anthropology and South Asian Studies at the University of Toronto. His research sits at the intersection of the anthropology of the state, science and technology studies, and the historical study of statistics and computing. He has worked on the collection, classification, and management of information in colonial and postcolonial India. In addition to prior training in computer science, he has worked in government agencies in the US and India on data science projects in education, health, and skill development at municipal, state, and federal levels.
+<div class="block">
+  <div class="label">II. Research interests</div>
+  <div class="body">
+    <ul class="bullets">
+      <li><span class="num">01</span><span>Colonial and postcolonial histories of statistics and statecraft</span></li>
+      <li><span class="num">02</span><span>Ethnography of the state and bureaucracy in South Asia</span></li>
+      <li><span class="num">03</span><span>Design, deployment, and maintenance of data infrastructures</span></li>
+      <li><span class="num">04</span><span>Caste, technoscience, and digital publics</span></li>
+      <li><span class="num">05</span><span>Mixed-method and collaborative approaches to studying governance technologies</span></li>
+    </ul>
+  </div>
+</div>
 
-His dissertation, *Governing Indeterminately: An Ethnography of Technopopulism from India*, draws on long-term fieldwork in Indian state and central bureaucracies to examine how digital infrastructures mediate development, statecraft, and fiscal federal relations. The research is funded by the International Development Research Centre (IDRC) and the Wenner-Gren Foundation for Anthropological Research.
+<div class="block">
+  <div class="label">III. Awards &amp; grants</div>
+  <div class="body">
+    <ul class="bullets">
+      <li><span class="num">2024</span><span>Writing Fellowship, Center for Ethnography, University of Toronto Scarborough</span></li>
+      <li><span class="num">2021</span><span>Dissertation Fieldwork Grant, Wenner-Gren Foundation for Anthropological Research</span></li>
+      <li><span class="num">2019</span><span>Doctoral Research Fellowship, International Development Research Centre (IDRC), Canada</span></li>
+    </ul>
+  </div>
+</div>
 
-He has previously published in *South Asia: Journal of South Asian Studies* and is a former Student Editor at *Cultural Anthropology*. He convened the interdisciplinary [Development Seminar](/utdevsem/) at the University of Toronto.
-
-* * *
-
-## Research
-
-* * *
-
-- Colonial and postcolonial histories of statistics and statecraft
-- Ethnography of the state and bureaucracy in South Asia
-- Design, deployment, and maintenance of data infrastructures
-- Caste, technoscience, and digital publics
-- Mixed-method and collaborative approaches to studying governance technologies
-
-* * *
-
-## Awards & Grants
-
-* * *
-
-<ul class="news-list">
-  <li>
-    <span class="news-date">2024</span>
-    <span>Writing Fellowship, Center for Ethnography, University of Toronto Scarborough.</span>
-  </li>
-  <li>
-    <span class="news-date">2021</span>
-    <span>Dissertation Fieldwork Grant, Wenner-Gren Foundation for Anthropological Research.</span>
-  </li>
-  <li>
-    <span class="news-date">2019</span>
-    <span>Doctoral Research Fellowship, International Development Research Centre (IDRC), Canada.</span>
-  </li>
-</ul>
-
-* * *
-
-## Recent News
-
-* * *
-
-<ul class="news-list">
-  <li>
-    <span class="news-date">Oct 2025</span>
-    <span>Talk at the International Federation for Library Associations and Institutions webinar: "Caste, Libraries, and Public Finance."</span>
-  </li>
-  <li>
-    <span class="news-date">Aug 2025</span>
-    <span>Invited talk at the Symposium on Digital Inequalities and the Global South, IIIT-Delhi.</span>
-  </li>
-  <li>
-    <span class="news-date">Apr 2025</span>
-    <span>Talk at the Center for South Asian Studies, University of Toronto Scarborough.</span>
-  </li>
-</ul>
-
-See all [talks](/talks/) and [publications](/publications/).
-
-* * *
+<div class="block">
+  <div class="label">IV. Recent news</div>
+  <div class="body">
+    <ul class="bullets news">
+      <li><span class="num">Oct 2025</span><span>Talk at the International Federation for Library Associations and Institutions webinar: &ldquo;Caste, Libraries, and Public Finance.&rdquo;</span></li>
+      <li><span class="num">Aug 2025</span><span>Invited talk at the Symposium on Digital Inequalities and the Global South, IIIT-Delhi.</span></li>
+      <li><span class="num">Apr 2025</span><span>Talk at the Center for South Asian Studies, University of Toronto Scarborough.</span></li>
+    </ul>
+    <p style="margin-top: 24px; font-size: 13px; font-family: var(--sans); color: var(--ink-3);">See all <a href="/talks/">talks</a> and <a href="/publications/">publications</a>.</p>
+  </div>
+</div>

--- a/projects.md
+++ b/projects.md
@@ -2,32 +2,38 @@
 layout: default
 title: Projects
 permalink: /projects/
+description: "Ongoing intellectual and public-facing projects by Aakash Solanki, sitting alongside the dissertation."
 ---
 
-## Projects
+<header class="pagehead">
+  <div>
+    <div class="kicker">Folio · Projects</div>
+    <h1>Alongside the dissertation.</h1>
+    <p class="standfirst">Ongoing intellectual and public-facing projects: sustained conversations, data work, and collaborations that run in parallel with the dissertation.</p>
+  </div>
+  <div class="meta">
+    <dl>
+      <dt>Active</dt><dd>3 projects</dd>
+      <dt>Since</dt><dd>2021</dd>
+      <dt>Geographies</dt><dd>India · Global</dd>
+      <dt>Mode</dt><dd>Collaborative</dd>
+    </dl>
+  </div>
+</header>
 
-* * *
+<article class="project">
+  <h2><a href="/caste-technoscience/">Caste as/of Technoscience</a></h2>
+  <p>A collaborative project with Dr. Palashi Vaghela (Canada Research Chair, Simon Fraser University) convening interdisciplinary conversations at the Society for Social Studies of Science (4S) since 2021. The project reframes caste not as an identity category layered onto technoscience but as a sociotechnical formation in its own right.</p>
+</article>
 
-Ongoing intellectual and public-facing projects, sitting alongside the dissertation.
+<article class="project">
+  <h2><a href="/freelibraries4all/">India Library Spend Tracker</a></h2>
+  <p>An interactive dashboard tracking public library spending across Indian states (2014–21), benchmarked against international peers. Examines the paradox of library legislation without library funding, the concentration of central grants, and the slow return of libraries to parliamentary attention. Developed as part of ongoing advocacy and research with the Free Libraries Network, India and South Asia.</p>
+</article>
 
-* * *
+<article class="project">
+  <h2>Critical Caste and Technology Studies Syllabus</h2>
+  <p>Supported Dr. Murali Shanmugavelan&rsquo;s Critical Caste and Technology Studies (CCTS) syllabus — a first-of-its-kind open resource organizing anti-caste scholarship around communicative practices, media, and internet technology studies. The syllabus offers a cross-disciplinary starting point for students and scholars examining caste as it is remanifested in everyday digital cultures.</p>
+</article>
 
-### [Caste as/of Technoscience](/caste-technoscience/)
-
-A collaborative project with Dr. Palashi Vaghela (Canada Research Chair, Simon Fraser University) convening interdisciplinary conversations at the Society for Social Studies of Science (4S) since 2021. The project reframes caste not as an identity category layered onto technoscience but as a sociotechnical formation in its own right.
-
-* * *
-
-### [India Library Spend Tracker](/freelibraries4all/)
-
-An interactive dashboard tracking public library spending across Indian states (2014–21), benchmarked against international peers. Examines the paradox of library legislation without library funding, the concentration of central grants, and the slow return of libraries to parliamentary attention. Developed as part of ongoing advocacy and research with the Free Libraries Network, India and South Asia.
-
-* * *
-
-### Critical Caste and Technology Studies Syllabus
-
-Supported Dr. Murali Shanmugavelan's Critical Caste and Technology Studies (CCTS) syllabus — a first-of-its-kind open resource organizing anti-caste scholarship around communicative practices, media, and internet technology studies. The syllabus offers a cross-disciplinary starting point for students and scholars examining caste as it is remanifested in everyday digital cultures.
-
-* * *
-
-[← Back to Stuff](/stuff/)
+<p class="back"><a href="/stuff/">← Back to Stuff</a></p>

--- a/publications.md
+++ b/publications.md
@@ -2,46 +2,115 @@
 layout: default
 title: Publications
 permalink: /publications/
+description: "Publications by Aakash Solanki: peer-reviewed articles, book chapters, interdisciplinary scholarly output, and public scholarship."
 ---
 
-## Publications
+<header class="pagehead">
+  <div>
+    <div class="kicker">Folio · Publications</div>
+    <h1>Writings.</h1>
+    <p class="standfirst">Peer-reviewed articles, book chapters, and public scholarship. Full texts linked where open-access; otherwise please write for a copy.</p>
+  </div>
+  <div class="meta">
+    <dl>
+      <dt>Articles</dt><dd>1 published · 3 under review</dd>
+      <dt>Chapters</dt><dd>1 published · 1 forthcoming</dd>
+      <dt>Proceedings</dt><dd>2 published · 1 R&amp;R</dd>
+      <dt>Public</dt><dd>2 essays</dd>
+    </dl>
+  </div>
+</header>
 
-* * *
+<h2 class="sect"><span class="n">§ 01</span>Peer-reviewed journal articles</h2>
 
-### Peer-reviewed journal articles
+<div class="pub">
+  <span class="yr">2019</span>
+  <div class="main">
+    <p class="title"><a href="https://doi.org/10.1080/00856401.2019.1603262">Management of Performance and Performance of Management: Getting to Work on Time in the Indian Bureaucracy</a></p>
+    <p class="venue">South Asia: Journal of South Asian Studies, 42(3): 588–605.</p>
+  </div>
+  <span class="tags">Article</span>
+</div>
 
-["Management of Performance and Performance of Management: Getting to Work on Time in the Indian Bureaucracy."](https://doi.org/10.1080/00856401.2019.1603262) *South Asia: Journal of South Asian Studies* 42(3): 588–605. 2019.
+<div class="pub">
+  <span class="yr">—</span>
+  <div class="main">
+    <p class="title">Three manuscripts currently under review at peer-reviewed journals.</p>
+    <p class="note">One manuscript in preparation: <em>Digitalization in a Different Key: A History of Management of Information Systems.</em></p>
+  </div>
+  <span class="tags">In progress</span>
+</div>
 
-Three manuscripts currently under review at peer-reviewed journals.
+<h2 class="sect"><span class="n">§ 02</span>Book chapters</h2>
 
-One manuscript in preparation: *Digitalization in a Different Key: A History of Management of Information Systems.*
+<div class="pub">
+  <span class="yr">Forth.</span>
+  <div class="main">
+    <p class="title">&ldquo;Is it really possible?&rdquo; Women public policy professionals and the promises and perils of a &ldquo;guerrilla&rdquo; data science.</p>
+  </div>
+  <span class="tags">Forthcoming</span>
+</div>
 
-* * *
+<div class="pub">
+  <span class="yr">2020</span>
+  <div class="main">
+    <p class="title"><a href="https://networkcultures.org/blog/publication/lives-of-data-essays-on-computational-cultures-from-india/">Untidy Data: Spreadsheet Practices in the Indian Bureaucracy</a></p>
+    <p class="venue">In Lives of Data: Essays on Computational Cultures from India, ed. Sandeep Mertia. Theory on Demand 39. Amsterdam: Institute of Network Cultures.</p>
+    <p class="note"><a href="https://player.fm/series/new-books-in-technology-2421470/sandeep-mertia-lives-of-data-essays-on-computational-cultures-from-india-institute-of-networked-cultures-2020">→ Podcast discussion</a></p>
+  </div>
+  <span class="tags">Chapter</span>
+</div>
 
-### Book chapters
+<h2 class="sect"><span class="n">§ 03</span>Interdisciplinary scholarly output</h2>
 
-Forthcoming. "'Is it really possible?' Women public policy professionals and the promises and perils of a 'guerrilla' data science."
+<div class="pub">
+  <span class="yr">2026</span>
+  <div class="main">
+    <p class="title"><a href="https://doi.org/10.1145/3772318.3791530">&ldquo;Studying Up&rdquo; through Digital Ethnography: The Case of Conservative Caste Enclaves</a></p>
+    <p class="venue">Proceedings of the 2026 CHI Conference on Human Factors in Computing Systems. ACM.</p>
+    <p class="note">With Ashique Ali Thuppilikkat and Priyank Chandra.</p>
+  </div>
+  <span class="tags">CHI</span>
+</div>
 
-["Untidy Data: Spreadsheet Practices in the Indian Bureaucracy."](https://networkcultures.org/blog/publication/lives-of-data-essays-on-computational-cultures-from-india/) In *Lives of Data: Essays on Computational Cultures from India*, edited by Sandeep Mertia. Theory on Demand 39. Amsterdam: Institute of Network Cultures. 2020. [Podcast discussion](https://player.fm/series/new-books-in-technology-2421470/sandeep-mertia-lives-of-data-essays-on-computational-cultures-from-india-institute-of-networked-cultures-2020).
+<div class="pub">
+  <span class="yr">—</span>
+  <div class="main">
+    <p class="title">Everyday Data Science: Notes from the Public Sector in India.</p>
+    <p class="venue">ACM Conference on Computer-Supported Cooperative Work and Social Computing (CSCW).</p>
+  </div>
+  <span class="tags">R&amp;R</span>
+</div>
 
-* * *
+<div class="pub">
+  <span class="yr">2016</span>
+  <div class="main">
+    <p class="title"><a href="https://doi.org/10.1111/1559-8918.2016.01107">Going Ethno in the Indian Bureaucracy</a></p>
+    <p class="venue">Ethnographic Praxis in Industry Conference Proceedings 2016(1): 501–521.</p>
+    <p class="note">With Tewari, S.</p>
+  </div>
+  <span class="tags">EPIC</span>
+</div>
 
-### Interdisciplinary scholarly output
+<h2 class="sect"><span class="n">§ 04</span>Public scholarship</h2>
 
-With Thuppilikkat, A. A., and Chandra, P. ["'Studying Up' through Digital Ethnography: The Case of Conservative Caste Enclaves."](https://doi.org/10.1145/3772318.3791530) *Proceedings of the 2026 CHI Conference on Human Factors in Computing Systems.* ACM, 2026.
+<div class="pub">
+  <span class="yr">2025</span>
+  <div class="main">
+    <p class="title"><a href="https://indianexpress.com/article/opinion/columns/india-start-ups-not-lacking-innovation-imagination-9974148/">India&rsquo;s start-ups are not lacking innovation but imagination</a></p>
+    <p class="venue">The Indian Express.</p>
+    <p class="note">With Mertia, S.</p>
+  </div>
+  <span class="tags">Op-ed</span>
+</div>
 
-With co-authors. "Everyday Data Science: Notes from the Public Sector in India." ACM Conference on Computer-Supported Cooperative Work and Social Computing (CSCW). *Revise and resubmit.*
+<div class="pub">
+  <span class="yr">2018</span>
+  <div class="main">
+    <p class="title"><a href="https://culanth.org/fieldsights/suddenly-statistics">Suddenly, Statistics?</a></p>
+    <p class="venue">Member Voices, Fieldsights.</p>
+  </div>
+  <span class="tags">Essay</span>
+</div>
 
-With Tewari, S. ["Going Ethno in the Indian Bureaucracy."](https://doi.org/10.1111/1559-8918.2016.01107) *Ethnographic Praxis in Industry Conference Proceedings* 2016(1): 501–521.
-
-* * *
-
-### Public scholarship
-
-With Mertia, S. ["India's start-ups are not lacking innovation but imagination."](https://indianexpress.com/article/opinion/columns/india-start-ups-not-lacking-innovation-imagination-9974148/) *The Indian Express*, 2025.
-
-["Suddenly, Statistics?"](https://culanth.org/fieldsights/suddenly-statistics) Member Voices, *Fieldsights*, May 2018.
-
-* * *
-
-[← Back to Stuff](/stuff/)
+<p class="back"><a href="/stuff/">← Back to Stuff</a></p>

--- a/stuff.md
+++ b/stuff.md
@@ -2,18 +2,29 @@
 layout: default
 title: Stuff
 permalink: /stuff/
+description: "Index of Aakash Solanki's publications, teaching, talks, projects, and blog."
 ---
 
-## Stuff
+<header class="pagehead">
+  <div>
+    <div class="kicker">Index</div>
+    <h1>Stuff.</h1>
+    <p class="standfirst">Writings, courses, lectures, projects, notes.</p>
+  </div>
+  <div class="meta">
+    <dl>
+      <dt>Sections</dt><dd>5</dd>
+      <dt>Updated</dt><dd>{{ site.time | date: '%b %Y' }}</dd>
+    </dl>
+  </div>
+</header>
 
-* * *
+<ul class="stuff-list">
+  <li><a href="/publications/">Publications</a></li>
+  <li><a href="/teaching/">Teaching</a></li>
+  <li><a href="/talks/">Talks</a></li>
+  <li><a href="/projects/">Projects</a></li>
+  <li><a href="/blog/">Blog</a></li>
+</ul>
 
-- [Publications](/publications/)
-- [Teaching](/teaching/)
-- [Talks](/talks/)
-- [Projects](/projects/)
-- [Blog](/blog/)
-
-* * *
-
-[← Back to About](/)
+<p class="back"><a href="/">← Back to About</a></p>

--- a/talks.md
+++ b/talks.md
@@ -2,61 +2,89 @@
 layout: default
 title: Talks
 permalink: /talks/
+description: "Recent talks, workshops, and invited presentations by Aakash Solanki."
 ---
 
-## Talks
+<header class="pagehead">
+  <div>
+    <div class="kicker">Folio · Talks</div>
+    <h1>Lectures &amp; panels.</h1>
+    <p class="standfirst">Recent invited lectures, conference presentations, and workshop talks. Slides and recordings available on request for most.</p>
+  </div>
+  <div class="meta">
+    <dl>
+      <dt>Since</dt><dd>2021</dd>
+      <dt>Recent</dt><dd>IFLA · IIIT-Delhi</dd>
+      <dt>Travel from</dt><dd>Toronto</dd>
+      <dt>Language</dt><dd>English · Hindi</dd>
+    </dl>
+  </div>
+</header>
 
-* * *
+<div class="talk">
+  <span class="dt">Oct 2025</span>
+  <span class="ttl">&ldquo;Caste, Libraries, and Public Finance&rdquo;</span>
+  <span class="at">IFLA webinar</span>
+</div>
 
-Recent talks, workshops, and invited presentations.
+<div class="talk">
+  <span class="dt">Aug 2025</span>
+  <span class="ttl">&ldquo;Infrastructures of IntraStatecraft: Digital Public Finance and the Mediation of Fiscal Federal Relations in India&rdquo;</span>
+  <span class="at">IIIT-Delhi (invited)</span>
+</div>
 
-<ul class="news-list">
-  <li>
-    <span class="news-date">Oct 2025</span>
-    <span>"Caste, Libraries, and Public Finance." Webinar, <em>Introduction to Caste for Librarians</em>, International Federation for Library Associations and Institutions.</span>
-  </li>
-  <li>
-    <span class="news-date">Aug 2025</span>
-    <span>"Infrastructures of IntraStatecraft: Digital Public Finance and the Mediation of Fiscal Federal Relations in India." Invited talk, Symposium on Digital Inequalities and the Global South, IIIT-Delhi.</span>
-  </li>
-  <li>
-    <span class="news-date">Apr 2025</span>
-    <span>"Rethinking the Emergence of the Poverty Line: The 1961 Census and Technopolitics of Governmentality in India." Center for South Asian Studies, University of Toronto Scarborough.</span>
-  </li>
-  <li>
-    <span class="news-date">Oct 2024</span>
-    <span>"Digital Infrastructures and the Mediation of Development." Center for Ethnography, University of Toronto Scarborough.</span>
-  </li>
-  <li>
-    <span class="news-date">Apr 2024</span>
-    <span>"'Can We Really Do It?' The Promise of a Guerrilla Data Practice." Cultures of Data Workshop, University of Pennsylvania.</span>
-  </li>
-  <li>
-    <span class="news-date">Feb 2024</span>
-    <span>"Politics and Poetics of a Formula." Invited talk, Cornell University.</span>
-  </li>
-  <li>
-    <span class="news-date">Jun 2023</span>
-    <span>"Maximum Data, Minimum Insights: Indian Bureaucracy's Tryst with Digital India." Invited presentation, University of Lucerne.</span>
-  </li>
-  <li>
-    <span class="news-date">Apr 2023</span>
-    <span>"Participant-Observation Tactics for Studying Up Among Elites." Guest lecture, Flame University, Pune.</span>
-  </li>
-  <li>
-    <span class="news-date">Dec 2022</span>
-    <span>"'Can You WhatsApp It to Me?' Mobile Data Dashboards and Evidence-Based Policy." Panel presentation, 4S Conference, Cholula.</span>
-  </li>
-  <li>
-    <span class="news-date">Jul 2021</span>
-    <span>"Surveying the MISes: Building Infrastructures to Monitor 'Outcomes' in India." Invited workshop, New Sciences New States Collective.</span>
-  </li>
-  <li>
-    <span class="news-date">Mar 2021</span>
-    <span>"Shoveling Data? Monitoring Outcomes in the Indian Public Sector." Invited workshop, Data and Society Institute, New York.</span>
-  </li>
-</ul>
+<div class="talk">
+  <span class="dt">Apr 2025</span>
+  <span class="ttl">&ldquo;Rethinking the Emergence of the Poverty Line: The 1961 Census and Technopolitics of Governmentality in India&rdquo;</span>
+  <span class="at">CSAS, U of Toronto Scarborough</span>
+</div>
 
-* * *
+<div class="talk">
+  <span class="dt">Oct 2024</span>
+  <span class="ttl">&ldquo;Digital Infrastructures and the Mediation of Development&rdquo;</span>
+  <span class="at">Center for Ethnography, UTSC</span>
+</div>
 
-[← Back to Stuff](/stuff/)
+<div class="talk">
+  <span class="dt">Apr 2024</span>
+  <span class="ttl">&ldquo;&lsquo;Can We Really Do It?&rsquo; The Promise of a Guerrilla Data Practice&rdquo;</span>
+  <span class="at">Cultures of Data Workshop, Penn</span>
+</div>
+
+<div class="talk">
+  <span class="dt">Feb 2024</span>
+  <span class="ttl">&ldquo;Politics and Poetics of a Formula&rdquo;</span>
+  <span class="at">Cornell University (invited)</span>
+</div>
+
+<div class="talk">
+  <span class="dt">Jun 2023</span>
+  <span class="ttl">&ldquo;Maximum Data, Minimum Insights: Indian Bureaucracy&rsquo;s Tryst with Digital India&rdquo;</span>
+  <span class="at">University of Lucerne (invited)</span>
+</div>
+
+<div class="talk">
+  <span class="dt">Apr 2023</span>
+  <span class="ttl">&ldquo;Participant-Observation Tactics for Studying Up Among Elites&rdquo;</span>
+  <span class="at">Flame University, Pune (guest)</span>
+</div>
+
+<div class="talk">
+  <span class="dt">Dec 2022</span>
+  <span class="ttl">&ldquo;&lsquo;Can You WhatsApp It to Me?&rsquo; Mobile Data Dashboards and Evidence-Based Policy&rdquo;</span>
+  <span class="at">4S Conference, Cholula</span>
+</div>
+
+<div class="talk">
+  <span class="dt">Jul 2021</span>
+  <span class="ttl">&ldquo;Surveying the MISes: Building Infrastructures to Monitor &lsquo;Outcomes&rsquo; in India&rdquo;</span>
+  <span class="at">New Sciences New States Collective</span>
+</div>
+
+<div class="talk">
+  <span class="dt">Mar 2021</span>
+  <span class="ttl">&ldquo;Shoveling Data? Monitoring Outcomes in the Indian Public Sector&rdquo;</span>
+  <span class="at">Data &amp; Society Institute, NY</span>
+</div>
+
+<p class="back"><a href="/stuff/">← Back to Stuff</a></p>

--- a/teaching.md
+++ b/teaching.md
@@ -2,38 +2,59 @@
 layout: default
 title: Teaching
 permalink: /teaching/
+description: "Undergraduate courses designed and taught as instructor of record at the University of Toronto."
 ---
 
-## Teaching
+<header class="pagehead">
+  <div>
+    <div class="kicker">Folio · Teaching</div>
+    <h1>In the seminar room.</h1>
+    <p class="standfirst">Courses designed and taught as instructor of record at the University of Toronto. Each course engages ethnographic and historical methods alongside contemporary debates in development, South Asia, and technology.</p>
+  </div>
+  <div class="meta">
+    <dl>
+      <dt>Dept.</dt><dd>Anthropology</dd>
+      <dt>Institution</dt><dd>U of Toronto</dd>
+      <dt>Level</dt><dd>Undergraduate</dd>
+      <dt>Campus</dt><dd>St. George · Mississauga</dd>
+    </dl>
+  </div>
+</header>
 
-* * *
+<div class="course">
+  <div class="role">Instructor of record</div>
+  <div>
+    <p class="title">CAS390H1F · Technology and Development in Asia</p>
+    <p class="desc">An interdisciplinary undergraduate course on the politics, technology, and culture of Asian development in the twentieth and twenty-first centuries. Situates contemporary debates about the &ldquo;Asian Century&rdquo; within longer histories of colonialism, postcolonial solidarity, and shifting global power. Topics include industrial strategy and technological competition across China, India, and Southeast Asia; the Washington and Beijing consensuses; populist nationalism; and the environmental stakes of Asian-led development in an age of artificial intelligence.</p>
+  </div>
+  <div class="when">
+    <span class="where">U of T, St. George</span>
+    Fall 2025
+  </div>
+</div>
 
-Courses designed and taught as instructor of record at the University of Toronto.
+<div class="course">
+  <div class="role">Instructor of record</div>
+  <div>
+    <p class="title">SAH200H5S · Being Human in South Asia</p>
+    <p class="desc">An interdisciplinary introduction to the study of South Asia, drawing on anthropology, history, political science, sociology, demography, economics, media studies, and science and technology studies. The course unpacks the Cold War formation of &ldquo;South Asian studies&rdquo; and examines contemporary debates through both scholarly texts and popular culture — film, news media, social media, and current affairs. Topics include colonial and anti-colonial histories, development, nationalism and partition, and the region&rsquo;s relation to its diasporas.</p>
+  </div>
+  <div class="when">
+    <span class="where">U of T, Mississauga</span>
+    Winter 2024
+  </div>
+</div>
 
-* * *
+<div class="course">
+  <div class="role">Instructor of record</div>
+  <div>
+    <p class="title">ANT374H1F · Rethinking Development</p>
+    <p class="desc">An undergraduate course tracing development — deliberate intervention to improve the lives of those deemed &ldquo;left behind&rdquo; — as concept and practice over the past century. Drawing on historical and ethnographic studies, the course engages global inequality, postcolonial politics, and the role of science and technology in the Global South. The 2023 iteration placed special emphasis on information, computation, and design: data-driven development, algorithmic decision-making for marginalized populations, and the promises and perils of artificial intelligence for &ldquo;social good.&rdquo;</p>
+  </div>
+  <div class="when">
+    <span class="where">U of T, St. George</span>
+    Fall 2023
+  </div>
+</div>
 
-### CAS390H1F: Technology and Development in Asia
-
-*Fall 2025 · University of Toronto, St. George*
-
-An interdisciplinary undergraduate course on the politics, technology, and culture of Asian development in the twentieth and twenty-first centuries. Situates contemporary debates about the "Asian Century" within longer histories of colonialism, postcolonial solidarity, and shifting global power. Topics include industrial strategy and technological competition across China, India, and Southeast Asia; the Washington and Beijing consensuses; populist nationalism; and the environmental stakes of Asian-led development in an age of artificial intelligence.
-
-* * *
-
-### SAH200H5S: Being Human in South Asia
-
-*Winter 2024 · University of Toronto, Mississauga*
-
-An interdisciplinary introduction to the study of South Asia, drawing on anthropology, history, political science, sociology, demography, economics, media studies, and science and technology studies. The course unpacks the Cold War formation of "South Asian studies" and examines contemporary debates through both scholarly texts and popular culture — film, news media, social media, and current affairs. Topics include colonial and anti-colonial histories, development, nationalism and partition, and the region's relation to its diasporas.
-
-* * *
-
-### ANT374H1F: Rethinking Development
-
-*Fall 2023 · University of Toronto, St. George*
-
-An undergraduate course tracing development — deliberate intervention to improve the lives of those deemed "left behind" — as concept and practice over the past century. Drawing on historical and ethnographic studies, the course engages global inequality, postcolonial politics, and the role of science and technology in the Global South. The 2023 iteration placed special emphasis on information, computation, and design: data-driven development, algorithmic decision-making for marginalized populations, and the promises and perils of artificial intelligence for "social good."
-
-* * *
-
-[← Back to Stuff](/stuff/)
+<p class="back"><a href="/stuff/">← Back to Stuff</a></p>

--- a/utdevsem.md
+++ b/utdevsem.md
@@ -2,26 +2,33 @@
 layout: default
 title: Development Seminar
 permalink: /utdevsem/
+description: "Concept note for the 2018-2019 Development Seminar series at the University of Toronto."
 ---
 
-**Development Seminar**
+<header class="pagehead">
+  <div>
+    <div class="kicker">Archive · 2017–2019</div>
+    <h1>Development Seminar.</h1>
+    <p class="standfirst">An interdisciplinary initiative at the University of Toronto, convening to critically examine global inequality, postcolonial politics, and power in the Global South. Coordinated with Tania Li (Anthropology) and Katherine Rankin (Geography).</p>
+  </div>
+  <div class="meta">
+    <dl>
+      <dt>Years</dt><dd>2017–2019</dd>
+      <dt>Host</dt><dd>U of Toronto</dd>
+    </dl>
+  </div>
+</header>
 
-*Note*: I ran the development seminar series at the University of Toronto between 2017 and 2019 along with Anthropologist Tania Li, and Geographer Katherine Rankin. What follows is a concept note on the seminar for 2018-2019.
+<div class="block">
+  <div class="label">Concept note · 2018–2019</div>
+  <div class="body">
+    <p>Guest speakers bring innovative research investigating migration, infrastructure, livelihoods, gender, and politics. In the 2017–2018 academic year, we hosted development studies scholars working at the intersection of gender and foreign aid, with emphasis on aid-giving institutions in the Global North — CIDA in Canada, USAID in the US.</p>
+    <p>The 2018–2019 series takes off from where we left in March: the politics of numbers behind development. Numbers — or to use a more current term, data (usually connoting numerical data) — are ubiquitous. Business organisations have talked for years about &ldquo;data as the new oil&rdquo;; governments, transnational aid agencies, Bretton Woods organisations, and others have turned to carefully exploring &ldquo;data&rdquo; as the new twenty-first century asset. The focus on numerical data — Big Data, machine learning, artificial intelligence — as the bedrock of informed policy and business decision-making is instrumental to understanding emerging changes in development practice.</p>
+    <p>There is a long history of computational techniques in development aid work. But with new media technologies, machine-readable data sets, and large-scale digital infrastructures, much of what USAID, CIDA, UKAID, Gates, MSDF, Omidyar, and others do is changing with particular data analytics and computing practices. This new &ldquo;data&rdquo; moment joins relatively older debates in ICTD, in mass media for development, and in internet for development. Microfinance now depends on cell phone data to predict financial behaviour; development projects are increasingly monitored on impact investment metrics; development impact bonds proliferate; public health work involves technology partners with the &ldquo;best&rdquo; data collection applications for malaria and TB interventions; insurance companies scramble for the &ldquo;best&rdquo; data on prospective clients.</p>
+    <p>What do we make of this &ldquo;Smartness Mandate&rdquo; (Orit Halpern, forthcoming) within development? Does attention to audit practices — say, of the Bill Gates Foundation — help us understand how calculative, computer-aided practices shape what development does, is, and becomes? The &ldquo;Will to Improve&rdquo; that Tania Li (2007) theorised a decade ago is now increasingly a human–computer assemblage of datasets being mined with (un)sophisticated machine learning. STS, information science, geography, anthropology, and environmental history have taken &ldquo;infrastructure&rdquo; as a matter of concern; STS and anthropology&rsquo;s focus on multiple ontologies opens new avenues for older concerns in development studies.</p>
+    <p>With these reflections in mind, the theme for 2018–2019 is <em>Development Infrastructures</em>. We invite scholars from information science, history of science, anthropology, geography, and STS to reflect on smartness, data-driven development, design in development, data and global health, data and state welfare.</p>
+    <p>For more, please see the <a href="https://utdevsem.wordpress.com" rel="noopener">seminar website</a>.</p>
+  </div>
+</div>
 
-The Development Seminar is an interdisciplinary initiative at the University of Toronto which convenes to critically examine issues of global inequality, postcolonial politics, and power in the Global South. Guest speakers bring their innovative research to investigate issues including migration, infrastructure, livelihoods, gender, and politics.
-
-In the 2017-2018 academic year, we hosted development studies scholars, working on issues at the intersection of gender and foreign aid with emphasis on aid-giving institutions in the Global North, such as CIDA in Canada, and USAID in the US.  
-
-The 2018-2019 development seminar series will take off from where we left in March on politics of numbers behind development. Numbers, or to use a more current term, data (usually connoting numerical data), are ubiquitous. Business organisations have already been talking about how ‘data is new oil’ whereas governments, transnational aid agencies, and Bretton woods organisations and others have also turned to carefully exploring ‘data’ as the new twenty-first century asset. The focus on numerical data—Big Data, and machine learning and artificial intelligence—as the bedrock of informed policy and business decision making is instrumental to understand the emerging changes in development practices. We see the influence of these newer infrastructures of knowledge, and development being invoked in the proposed smart city in Toronto, and the many AI strategy papers being put out by various governments within the last year.
-
-There is clearly a very long history of use of computational techniques in development aid work. However, with new media technologies, creation and availability of machine readable data sets, and the building of large scale digital infrastructures, much of the work that USAID, CIDA, UKAID, Gates, MSDF, Omidyar Network, and others do is changing with particular data analytics and computing practices. This new ‘data’ moment joins the relatively older debates in ICTD, mass media such as TV, radio for development, internet for development (Facebook’s infamous efforts in Myanmar or Google Internet Balloons in Africa). Much of micro finance work now depends on fetching people’s cell phone use data to predict their financial behaviour and credit ratings—whether in Bangladesh or Kenya—using mobile money and mobile wallets to promise  brick and mortar less banking in places where banks haven’t been able to reach. Development projects are increasingly monitored and evaluated based on impact investment metrics, while development impact bonds (DIB) are proliferating. Public Health work is increasingly relying on involving technology partners with the best data collection applications so that programs for malaria, and TB interventions can be monitored appropriately, while insurance companies scramble for the ‘best' data on prospective clients. 
-
-What do we make of this ‘Smartness Mandate’ (Orit Halpern, forthcoming) within development? Does focus on audit practices of—say the Bill Gates Foundation— help us understand how calculative/computer aided practices shapes what development does, is, and becomes? The ‘Will to Improve’ that Tania Li (2007) theorised a decade ago, is now increasingly a human-computer assemblage of datasets being mined by data scientists using (un)sophisticated machine learning algorithms. Conversations in STS, information science, and more recently geography, anthropology, and environmental history have taken on ‘infrastructure’ as a matter of concern whereas STS, and more recently anthropology’s focus on multiple ontologies opens new avenues to approach older concerns in development studies. 
-
-With these reflections in mind, the theme for the 2018-2019 year is ‘Development Infrastructures’.  We plan to invite a set of scholars ranging from information science, history of science, anthropology, geography, and STS to reflect on ‘smartness’, data driven development, design in development, data and global health, data and state welfare, among others.
-
-For more, please see the [seminar website](https://utdevsem.wordpress.com)
-
-* * *
-
-[← Back to About](/)
+<p class="back"><a href="/">← Back to About</a></p>


### PR DESCRIPTION
## Summary
- Replace orderedlist theme CSS with a typography-first editorial system (Newsreader + Inter + JetBrains Mono via Bunny Fonts)
- Warm paper palette in oklch with dusty-ochre accent; dark mode preserved
- Single-line masthead + nav; hero lede with portrait on home; labeled content blocks; pagehead + kicker on sub-pages
- Strong SEO: Highwire Press, Dublin Core, Open Graph, Twitter cards, schema.org Person JSON-LD
- Accessibility: skip link, focus-visible rings, reduced-motion, semantic landmarks
- Skips side rail (minimalism) and newsletter form (blog is the newsletter)

## Test plan
- [ ] Browse each page on the preview — About, Stuff, Publications, Teaching, Talks, Projects, Caste as/of Technoscience, Contact, Blog, Development Seminar
- [ ] Toggle dark mode
- [ ] Check nav active state on each page
- [ ] Verify fonts load (Newsreader serif, Inter sans)
- [ ] Verify portrait renders on home
- [ ] Verify footer + back links

**Not merging yet** — waiting for visual review before shipping to gh-pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)