### PR TITLE
Add quiet bodhi leaf + Ambedkarite-blue accent

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -74,7 +74,7 @@
     </script>
     {% endif %}
 
-    <link rel="icon" href="{{ '/assets/img/favicon.svg' | relative_url }}" type="image/svg+xml">
+    <link rel="icon" href="{{ '/assets/img/bodhi.svg' | relative_url }}" type="image/svg+xml">
     <link rel="preconnect" href="https://fonts.bunny.net" crossorigin>
     <link rel="stylesheet" href="https://fonts.bunny.net/css?family=newsreader:400,400i,500,500i,600|inter:400,500,600|jetbrains-mono:400,500&display=swap">
     <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">
@@ -102,6 +102,16 @@
 
       <footer class="site">
         <span>© {{ site.time | date: '%Y' }} {{ site.author }} · Set in Newsreader &amp; Inter</span>
+        <span class="ornament" aria-hidden="true">
+          <svg viewBox="0 0 130 130" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M 65 110 C 45 112 27 98 25 75 C 23 48 41 25 65 15 C 89 25 107 48 105 75 C 103 98 85 112 65 110 Z"/>
+            <path d="M 65 15 L 65 110"/>
+            <path d="M 65 110 L 65 122"/>
+            <path d="M 65 38 Q 53 46 40 53"/><path d="M 65 38 Q 77 46 90 53"/>
+            <path d="M 65 60 Q 51 68 36 75"/><path d="M 65 60 Q 79 68 94 75"/>
+            <path d="M 65 82 Q 54 90 47 96"/><path d="M 65 82 Q 76 90 83 96"/>
+          </svg>
+        </span>
         <span><a href="{{ site.orcid }}" rel="noopener">ORCID</a> · <a href="{{ '/feed.xml' | relative_url }}">RSS feed</a></span>
       </footer>
     </div>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -9,6 +9,7 @@
   --rule:     oklch(0.85  0.010 75);
   --accent:   oklch(0.52  0.11  55);
   --accent-2: oklch(0.72  0.09  55);
+  --accent-blue: oklch(0.42 0.14 252);
   --highlight:oklch(0.94  0.06  92);
 
   --serif: "Newsreader", Georgia, serif;
@@ -32,6 +33,7 @@
   --rule:     oklch(0.32 0.010 60);
   --accent:   oklch(0.72 0.12 60);
   --accent-2: oklch(0.62 0.10 60);
+  --accent-blue: oklch(0.68 0.13 250);
   --highlight:oklch(0.32 0.05 80);
 }
 
@@ -114,7 +116,7 @@ a { color: var(--ink); }
 .mast-nav a.active::after {
   content: ''; position: absolute;
   left: 0; right: 0; bottom: -19px;
-  height: 2px; background: var(--accent);
+  height: 2px; background: var(--accent-blue);
 }
 
 #theme-toggle {
@@ -675,11 +677,23 @@ footer.site {
   color: var(--ink-3);
   display: flex;
   justify-content: space-between;
+  align-items: center;
   gap: 24px;
   flex-wrap: wrap;
 }
 footer.site a { color: var(--ink-3); text-decoration: none; }
 footer.site a:hover { color: var(--accent); }
+footer.site .ornament {
+  width: 18px;
+  height: 18px;
+  color: var(--accent-blue);
+  opacity: 0.85;
+  flex-shrink: 0;
+  display: inline-flex;
+}
+footer.site .ornament svg {
+  width: 100%; height: 100%;
+}
 
 /* ── Research page ────────────────────────────────────────── */
 .research-hero,

--- a/assets/img/bodhi.svg
+++ b/assets/img/bodhi.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 130 130" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+  <path d="M 65 110 C 45 112 27 98 25 75 C 23 48 41 25 65 15 C 89 25 107 48 105 75 C 103 98 85 112 65 110 Z"/>
+  <path d="M 65 15 L 65 110"/>
+  <path d="M 65 110 L 65 122"/>
+  <path d="M 65 38 Q 53 46 40 53"/>
+  <path d="M 65 38 Q 77 46 90 53"/>
+  <path d="M 65 60 Q 51 68 36 75"/>
+  <path d="M 65 60 Q 79 68 94 75"/>
+  <path d="M 65 82 Q 54 90 47 96"/>
+  <path d="M 65 82 Q 76 90 83 96"/>
+</svg>


### PR DESCRIPTION
Subtle visual signal: peepal-leaf favicon, same leaf as a small footer mark in cobalt, and the active-nav underline switches to the cobalt.