### PR TITLE
More bodhi + Wenner-Gren link

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -278,8 +278,34 @@ main pre code { background: none; padding: 0; }
   gap: 40px;
   padding: 32px 0;
   border-top: 1px solid var(--rule);
+  position: relative;
 }
 .block:last-of-type { border-bottom: 1px solid var(--rule); }
+.block:not(:first-of-type)::before {
+  content: '';
+  position: absolute;
+  top: -1px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 44px;
+  height: 2px;
+  background: var(--paper);
+  z-index: 1;
+}
+.block:not(:first-of-type)::after {
+  content: '';
+  position: absolute;
+  top: -18px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 26px;
+  height: 32px;
+  background-color: var(--accent-blue);
+  -webkit-mask: url('/assets/img/bodhi.svg') no-repeat center / contain;
+  mask: url('/assets/img/bodhi.svg') no-repeat center / contain;
+  opacity: 0.85;
+  z-index: 2;
+}
 .block .label {
   font: 500 11px/1.3 var(--sans);
   letter-spacing: 0.15em; text-transform: uppercase;
@@ -726,8 +752,34 @@ footer.site .ornament svg {
   margin: 32px 0;
   padding: 32px 0;
   border-top: 1px solid var(--rule);
+  position: relative;
 }
 .thread:last-of-type { border-bottom: 1px solid var(--rule); }
+.thread::before {
+  content: '';
+  position: absolute;
+  top: -1px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 44px;
+  height: 2px;
+  background: var(--paper);
+  z-index: 1;
+}
+.thread::after {
+  content: '';
+  position: absolute;
+  top: -18px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 26px;
+  height: 32px;
+  background-color: var(--accent-blue);
+  -webkit-mask: url('/assets/img/bodhi.svg') no-repeat center / contain;
+  mask: url('/assets/img/bodhi.svg') no-repeat center / contain;
+  opacity: 0.85;
+  z-index: 2;
+}
 .thread h3 {
   font: 500 italic 1.5rem/1.25 var(--serif);
   color: var(--ink);

--- a/assets/img/bodhi.svg
+++ b/assets/img/bodhi.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 130 130" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 130 130" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" color="#2a3680" aria-hidden="true">
   <path d="M 65 110 C 45 112 27 98 25 75 C 23 48 41 25 65 15 C 89 25 107 48 105 75 C 103 98 85 112 65 110 Z"/>
   <path d="M 65 15 L 65 110"/>
   <path d="M 65 110 L 65 122"/>

--- a/assets/img/wheel.svg
+++ b/assets/img/wheel.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" color="#2a3680" aria-hidden="true">
+  <circle cx="50" cy="50" r="42"/>
+  <circle cx="50" cy="50" r="6"/>
+  <line x1="50" y1="8" x2="50" y2="92"/>
+  <line x1="8" y1="50" x2="92" y2="50"/>
+  <line x1="20.3" y1="20.3" x2="79.7" y2="79.7"/>
+  <line x1="79.7" y1="20.3" x2="20.3" y2="79.7"/>
+</svg>

--- a/research.md
+++ b/research.md
@@ -16,7 +16,7 @@ description: "An ethnography of governance after planning — regional inequalit
       <dt>Fieldwork</dt><dd>2019–2023</dd>
       <dt>Sites</dt><dd>National capital · state capitals · districts</dd>
       <dt>Archive</dt><dd>1950–present</dd>
-      <dt>Funded by</dt><dd>IDRC · Wenner-Gren</dd>
+      <dt>Funded by</dt><dd>IDRC · <a target="_blank" rel="noopener noreferrer" href="https://wennergren.org/grantee/aakash-solanki/">Wenner-Gren</a></dd>
     </dl>
   </div>
 </header>


### PR DESCRIPTION
Section dividers now carry a small blue bodhi leaf. Favicon renders cobalt. Adds dharmachakra SVG for later use. Links the Wenner-Gren mention on Research.