### PR TITLE
Portrait symmetry; pamphlets/instrument tweaks; screen restored

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -223,11 +223,15 @@ main pre code { background: none; padding: 0; }
   display: grid;
   grid-template-columns: 1fr 280px;
   gap: 72px;
-  align-items: start;
+  align-items: stretch;
   padding-bottom: 48px;
   border-bottom: 1px solid var(--rule);
   margin-bottom: 32px;
   position: relative;
+}
+.lede > :nth-child(2) {
+  display: flex;
+  align-items: stretch;
 }
 .lede::before {
   content: '';
@@ -277,14 +281,19 @@ main pre code { background: none; padding: 0; }
 }
 .lede .portrait {
   width: 100%;
-  aspect-ratio: 4/5;
+  flex: 1;
   background: var(--paper-3);
   overflow: hidden;
   border-radius: 2px;
+  min-height: 280px;
 }
 .lede .portrait img {
   width: 100%; height: 100%;
   object-fit: cover;
+}
+@media (max-width: 820px) {
+  .lede > :nth-child(2) { display: block; }
+  .lede .portrait { aspect-ratio: 1/1; flex: none; }
 }
 .lede .portrait-cap {
   font: 400 italic 12px/1.4 var(--serif);

--- a/caste-technoscience.md
+++ b/caste-technoscience.md
@@ -39,7 +39,7 @@ description: "An ongoing collaborative project convening interdisciplinary conve
 </div>
 
 <figure class="page-figure">
-  <img src="/assets/img/research/screen.jpeg" alt="Two people leaning over a desktop screen in a cramped office, working through a form together." loading="lazy">
+  <img src="/assets/img/research/screen.jpeg" alt="Two people leaning over a desktop screen in a cramped office, working through a form together — seen from behind." loading="lazy">
 </figure>
 
 <div class="stupa-coda" role="presentation"></div>

--- a/research.md
+++ b/research.md
@@ -32,10 +32,6 @@ description: "An ethnography of governance after planning — regional inequalit
     <p>For most of the twentieth century, the developmental authority of postcolonial states rested on a particular epistemic claim — that the state could know, through statistics, surveys, and resource assessments, the social and economic processes it sought to govern. By the early twenty-first century, that claim no longer holds steady. National statistical infrastructures have lost authority and coverage; new digital infrastructures have not yet consolidated reliability.</p>
     <p>The dissertation pursues what it means to govern through this interregnum. Drawing on three years of fieldwork and archival research reaching back to the postcolonial planning institutions of the 1950s, it argues that contemporary modes of governing do not retreat from technical infrastructure when its epistemic ground gives way. Instead, they redeploy it for other purposes — to generate political rhythm, competitive community, and the spectacular performance of governance improvement.</p>
     <p>The state is not the only actor in this story. The work also tracks the cast that has come to populate the conditions of national governance: transnational funding agencies, philanthrocapitalist foundations, multinational technology corporations, and financial experiments such as development impact bonds — whose tools, money, instruments, and expertise reshape what the state is able to do, and what it is asked to do, by those it governs.</p>
-    <figure class="inline-figure">
-      <img src="/assets/img/research/pamphlets.jpeg" alt="A welfare counter labelled &lsquo;EC CORNER&rsquo; with stacks of bilingual pamphlets in Kannada and a wall chart explaining symptoms of low blood sugar." loading="lazy">
-      <figcaption>The materials of public-health communication, stacked at a counter.</figcaption>
-    </figure>
   </div>
 </div>
 
@@ -97,7 +93,7 @@ description: "An ethnography of governance after planning — regional inequalit
     <p>Ethnography in bureaucratic settings; archival work in national and state collections; participant-observation alongside policy consultants and frontline workers; document analysis across cabinet resolutions, programme guidelines, and digital portals. The project moves between offices and districts, between papers tabled in parliament and forms filled at the block level.</p>
     <figure class="inline-figure">
       <img src="/assets/img/research/instrument.jpeg" alt="A handheld haemoglobin-screening device held in a hand, with a smartphone visible on a desk in the background." loading="lazy">
-      <figcaption>An instrument of measure, in the field.</figcaption>
+      <figcaption>Anemia measurement.</figcaption>
     </figure>
   </div>
 </div>


### PR DESCRIPTION
Resize portrait to match text height; remove pamphlets figure from Research; instrument figcaption now 'Anemia measurement'; restore screen.jpeg on Caste/Technoscience.