### PR TITLE
Add DRAD and Library Tracker project pages

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -761,6 +761,20 @@ main pre code { background: none; padding: 0; }
   opacity: 0.7;
 }
 
+/* ── CTA link (used on project pages) ─────────────────────── */
+.cta {
+  display: inline-block;
+  font: 500 14px/1 var(--sans);
+  letter-spacing: 0.04em;
+  color: var(--paper);
+  background: var(--accent-blue);
+  padding: 12px 18px;
+  border-radius: 3px;
+  text-decoration: none;
+  transition: background-color 0.15s var(--ease);
+}
+.cta:hover { background: var(--ink); color: var(--paper); }
+
 /* ── Back link ────────────────────────────────────────────── */
 .back {
   margin: 64px 0 0;

--- a/digital-rights-activism-dialogues.md
+++ b/digital-rights-activism-dialogues.md
@@ -1,0 +1,58 @@
+---
+layout: default
+title: Digital Rights Activism Dialogues
+permalink: /digital-rights-activism-dialogues/
+description: "A King's College London online dialogue series on digital rights activism in the Global South, co-curated with Dr. Tarangini Sriraman."
+---
+
+<header class="pagehead">
+  <div>
+    <div class="kicker">Project</div>
+    <h1>Digital Rights Activism Dialogues.</h1>
+    <p class="standfirst">An online dialogue series at King&rsquo;s College London, co-curated with Dr. <a target="_blank" rel="noopener noreferrer" href="https://www.kcl.ac.uk/people/tarangini-sriraman">Tarangini Sriraman</a>, pairing activists and activism-adjacent academics across regional geographies of the Global South.</p>
+  </div>
+  <div class="meta">
+    <dl>
+      <dt>Venue</dt><dd>King&rsquo;s College London</dd>
+      <dt>Co-curator</dt><dd><a target="_blank" rel="noopener noreferrer" href="https://www.kcl.ac.uk/people/tarangini-sriraman">Tarangini Sriraman</a></dd>
+      <dt>Series page</dt><dd><a target="_blank" rel="noopener noreferrer" href="https://www.kcl.ac.uk/events/series/digital-rights-activism-dialogues">KCL events &rarr;</a></dd>
+    </dl>
+  </div>
+</header>
+
+<div class="block">
+  <div class="label">The question</div>
+  <div class="body">
+    <p>Even as the hype over the promises and perils of large language models, the increasing financialization of everyday life, digital public infrastructures, and e-currency engulfs the zeitgeist, this series steers conversations away from corporation-dominated discourses toward transnational activist energies across the Global South.</p>
+    <p>The digital-rights activist movement contains multitudes &mdash; civic hackers, responsible-data activists, right-to-information advocates, civil-rights lawyers, anti-caste activists, data feminists, anti-national-ID and privacy activists, leading curators of the archival commons. Race, caste, ethnicity, gender, and sexuality have filtered the often invisible labour of this work. These movements are scattered in their respective publics and goalposts but are marked by potential solidarities against capitalist surveillance, automated injustice, and often state-enabled cyber violence.</p>
+  </div>
+</div>
+
+<div class="block">
+  <div class="label">Format</div>
+  <div class="body">
+    <p>Each conversation pairs two or more activists or activism-adjacent academics speaking to a particular clustering of digital rights across regional geographies of the Global South, moderated by an academic working in an adjacent research area. Each speaker offers a historical reflection on how digital-rights activism emerged in a particular regional site of collective struggle &mdash; tracing the arc from lawfare and authoritarian displeasure to crony-capitalist capture and fascist techno-solutionism &mdash; and reflects on what this has meant for an immediate struggle: a lawsuit, rights advocacy, coalition, movement-building.</p>
+  </div>
+</div>
+
+<div class="block">
+  <div class="label">Themes</div>
+  <div class="body">
+    <p><strong>Social media and cyber security.</strong> Histories of digital-rights mobilisation, moderation, and de-policing; cyber-harassment formulations re-centred on caste, communal, and gendered violence; the social, economic, and psychological harms incurred by content moderators training large language models on behalf of tech companies.</p>
+    <p><strong>Social services.</strong> Cash transfers and apps that necessitate the &ldquo;performance evaluation&rdquo; of health workers; the entry of philanthropic actors into welfare provisioning under post-2000 conditions; debates on food and health security and the burdens placed on data workers.</p>
+    <p><strong>Financial inclusion.</strong> Critical engagements with regulatory innovation in the digital-payments ecosystem, welfare payments via tech-company platforms, and what small thrift-driven self-help-group models offer in this landscape.</p>
+    <p><strong>Counter-forensics.</strong> Activists, scholars, and journalists responding to corporate and state surveillance via advanced computing and counter-surveillance toolkits &mdash; inverting the institutionalised forensic gaze, with activist individuals and organisations taking over the means of evidence production.</p>
+  </div>
+</div>
+
+<div class="block">
+  <div class="label">Hosts and partners</div>
+  <div class="body">
+    <p>Hosted by the <a target="_blank" rel="noopener noreferrer" href="https://www.kcl.ac.uk/history">History Department at King&rsquo;s College London</a> in collaboration with the Labor Tech Network, the King&rsquo;s India Institute, the Africa Leadership Centre, the Brazil Institute, and the Menzies Australia Institute.</p>
+    <p>Full series and upcoming dialogues: <a target="_blank" rel="noopener noreferrer" href="https://www.kcl.ac.uk/events/series/digital-rights-activism-dialogues">kcl.ac.uk/events/series/digital-rights-activism-dialogues</a>.</p>
+  </div>
+</div>
+
+<div class="stupa-coda" role="presentation"></div>
+
+<p class="back"><a href="/projects/">← Back to Projects</a></p>

--- a/libraries.md
+++ b/libraries.md
@@ -1,0 +1,58 @@
+---
+layout: default
+title: India Library Spend Tracker
+permalink: /libraries/
+description: "A brief on public library spending in India, with an interactive state-by-state dashboard, developed alongside the Free Libraries Network."
+---
+
+<header class="pagehead">
+  <div>
+    <div class="kicker">Project</div>
+    <h1>What India spends on its public libraries.</h1>
+    <p class="standfirst">A brief on public library spending across Indian states, with an interactive state-by-state dashboard. The work sits alongside ongoing advocacy and research with the Free Libraries Network, India and South Asia.</p>
+  </div>
+  <div class="meta">
+    <dl>
+      <dt>Period</dt><dd>2014&ndash;21</dd>
+      <dt>Geography</dt><dd>31 Indian states</dd>
+      <dt>Partner</dt><dd>Free Libraries Network</dd>
+      <dt>Tracker</dt><dd><a href="/freelibraries4all/">View dashboard &rarr;</a></dd>
+    </dl>
+  </div>
+</header>
+
+<div class="block">
+  <div class="label">The question</div>
+  <div class="body">
+    <p>Public libraries are unevenly funded, unevenly spoken about, and unevenly attended to as a public good. India spends a fraction of what comparable countries spend on public libraries; even within India, spending is concentrated in a few states while most receive almost nothing from the central pot. The first step in changing that is to make the numbers legible.</p>
+    <p>This project is a primer and a tracker. It pulls public-finance figures from state and central sources, benchmarks them against international peers, and presents a state-by-state view of what is spent and where it goes.</p>
+  </div>
+</div>
+
+<div class="block">
+  <div class="label">What the data shows</div>
+  <div class="body">
+    <p><strong>Per-capita spend.</strong> India&rsquo;s public-library expenditure works out to about &#8377;15.30 per person per year (2020&ndash;21). That is roughly 232 times less than the United States in nominal terms, and around 80 times less than Finland after adjusting for purchasing power. Goa, the highest-spending Indian state, reaches about &#8377;140 per capita &mdash; still well below UK levels.</p>
+    <p><strong>Library acts without library money.</strong> Of the fourteen Indian states with library legislation, ten spend below the national average. Legislation alone does not guarantee funding.</p>
+    <p><strong>Concentration of central grants.</strong> The Raja Rammohun Roy Library Foundation (RRRLF) saw a 3.7&times; jump in funding after the National Mission on Libraries was launched in 2012. But distribution is concentrated: in 2023&ndash;24, four states absorbed roughly 70 percent of releases, while eighteen states received zero.</p>
+  </div>
+</div>
+
+<div class="block">
+  <div class="label">Parliament returns to libraries</div>
+  <div class="body">
+    <p>For years, public libraries received little parliamentary scrutiny. The July&ndash;August 2025 budget session marked a small shift: questions on library equity and regional funding gaps appeared more frequently than in any recent session. The tracker logs these questions alongside the spending data, so that legislative attention and fiscal practice can be read together.</p>
+  </div>
+</div>
+
+<div class="block">
+  <div class="label">The dashboard</div>
+  <div class="body">
+    <p>The interactive tracker is the working face of this project &mdash; sortable, downloadable, and updated as new state-level data becomes available.</p>
+    <p style="margin-top: 18px;"><a href="/freelibraries4all/" class="cta">Open the India Library Spend Tracker &rarr;</a></p>
+  </div>
+</div>
+
+<div class="stupa-coda" role="presentation"></div>
+
+<p class="back"><a href="/projects/">← Back to Projects</a></p>

--- a/projects.md
+++ b/projects.md
@@ -27,13 +27,13 @@ description: "Ongoing intellectual and public-facing projects by Aakash Solanki,
 </article>
 
 <article class="project">
-  <h2><a target="_blank" rel="noopener noreferrer" href="https://www.kcl.ac.uk/events/series/digital-rights-activism-dialogues">Digital Rights Activism Dialogues</a></h2>
-  <p>An online dialogue series co-curated with Dr. <a target="_blank" rel="noopener noreferrer" href="https://www.kcl.ac.uk/people/tarangini-sriraman">Tarangini Sriraman</a> at King&rsquo;s College London, hosted by the KCL History Department in collaboration with the Labor Tech Network, King&rsquo;s India Institute, Africa Leadership Centre, Brazil Institute, and Menzies Australia Institute. Each conversation pairs activists and activism-adjacent academics across regional geographies of the Global South &mdash; labour, health, food, policing, identification, housing, archiving &mdash; to steer the digital-rights conversation away from corporation-dominated discourse toward transnational activist energies. Themes include digital rights in social media and cyber security, social services, financial inclusion, and counter-forensics.</p>
+  <h2><a href="/digital-rights-activism-dialogues/">Digital Rights Activism Dialogues</a></h2>
+  <p>An online dialogue series at King&rsquo;s College London co-curated with Dr. <a target="_blank" rel="noopener noreferrer" href="https://www.kcl.ac.uk/people/tarangini-sriraman">Tarangini Sriraman</a>. Each conversation pairs activists and activism-adjacent academics across regional geographies of the Global South to steer the digital-rights conversation away from corporation-dominated discourse toward transnational activist energies.</p>
 </article>
 
 <article class="project">
-  <h2><a href="/freelibraries4all/">India Library Spend Tracker</a></h2>
-  <p>An interactive dashboard tracking public library spending across Indian states (2014–21), benchmarked against international peers. Examines the paradox of library legislation without library funding, the concentration of central grants, and the slow return of libraries to parliamentary attention. Developed as part of ongoing advocacy and research with the Free Libraries Network, India and South Asia.</p>
+  <h2><a href="/libraries/">India Library Spend Tracker</a></h2>
+  <p>A primer on what India spends on its public libraries, with an interactive state-by-state dashboard. Examines the paradox of library legislation without library funding, the concentration of central grants, and the slow return of libraries to parliamentary attention. Developed alongside ongoing advocacy and research with the Free Libraries Network, India and South Asia.</p>
 </article>
 
 <article class="project">


### PR DESCRIPTION
Each project now has a brief on the site before the external link.