### PR TITLE
Make bodhi favicon adapt to dark-mode tab strips

### DIFF
--- a/assets/img/bodhi.svg
+++ b/assets/img/bodhi.svg
@@ -1,4 +1,8 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 130 130" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" color="#2a3680" aria-hidden="true">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 130 130" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+  <style>
+    :root { color: #2a3680; }
+    @media (prefers-color-scheme: dark) { :root { color: #f7f2e8; } }
+  </style>
   <path d="M 65 110 C 45 112 27 98 25 75 C 23 48 41 25 65 15 C 89 25 107 48 105 75 C 103 98 85 112 65 110 Z"/>
   <path d="M 65 15 L 65 110"/>
   <path d="M 65 110 L 65 122"/>


### PR DESCRIPTION
## Summary
- Inline `prefers-color-scheme` media query in `assets/img/bodhi.svg`
- Light mode: cobalt `#2a3680` (unchanged)
- Dark mode: warm cream `#f7f2e8` so the leaf stays visible against dark tab strips

## Test plan
- [ ] Tab favicon visible in Safari/Chrome light mode
- [ ] Tab favicon visible in Safari/Chrome dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)