### PR TITLE
Fix favicon rendering in Chrome (split light/dark variants)

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -80,7 +80,8 @@
     </script>
     {% endif %}
 
-    <link rel="icon" href="{{ '/assets/img/bodhi.svg' | relative_url }}" type="image/svg+xml">
+    <link rel="icon" href="{{ '/assets/img/bodhi.svg' | relative_url }}" type="image/svg+xml" media="(prefers-color-scheme: light)">
+    <link rel="icon" href="{{ '/assets/img/bodhi-dark.svg' | relative_url }}" type="image/svg+xml" media="(prefers-color-scheme: dark)">
     <link rel="preconnect" href="https://fonts.bunny.net" crossorigin>
     <link rel="stylesheet" href="https://fonts.bunny.net/css?family=newsreader:400,400i,500,500i,600|inter:400,500,600|jetbrains-mono:400,500&display=swap">
     <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">

--- a/assets/img/bodhi-dark.svg
+++ b/assets/img/bodhi-dark.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 130 130" fill="none" stroke="#2a3680" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 130 130" fill="none" stroke="#f7f2e8" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
   <path d="M 65 110 C 45 112 27 98 25 75 C 23 48 41 25 65 15 C 89 25 107 48 105 75 C 103 98 85 112 65 110 Z"/>
   <path d="M 65 15 L 65 110"/>
   <path d="M 65 110 L 65 122"/>


### PR DESCRIPTION
## Summary
- Chrome doesn't reliably apply `prefers-color-scheme` inside an SVG favicon's `<style>` block — Safari does, Chrome falls back to no-colour
- Split into two hardcoded SVGs and switch via `<link media>` attribute, which both browsers handle consistently
- `bodhi.svg`: cobalt `#2a3680` for light mode (the original)
- `bodhi-dark.svg`: cream `#f7f2e8` for dark mode (new)

## Test plan
- [ ] Chrome light mode: cobalt leaf visible in tab
- [ ] Chrome dark mode: cream leaf visible in tab
- [ ] Safari light + dark: still working