### PR TITLE
Bolder favicon veins for 16px legibility

### DIFF
--- a/assets/img/bodhi.svg
+++ b/assets/img/bodhi.svg
@@ -1,13 +1,11 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 130 130" aria-hidden="true">
   <path d="M 65 110 C 45 112 27 98 25 75 C 23 48 41 25 65 15 C 89 25 107 48 105 75 C 103 98 85 112 65 110 Z" fill="#2a3680"/>
-  <g fill="none" stroke="#f7f2e8" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+  <g fill="none" stroke="#ffffff" stroke-width="6" stroke-linecap="round" stroke-linejoin="round">
     <path d="M 65 15 L 65 110"/>
     <path d="M 65 38 Q 53 46 40 53"/>
     <path d="M 65 38 Q 77 46 90 53"/>
     <path d="M 65 60 Q 51 68 36 75"/>
     <path d="M 65 60 Q 79 68 94 75"/>
-    <path d="M 65 82 Q 54 90 47 96"/>
-    <path d="M 65 82 Q 76 90 83 96"/>
   </g>
   <path d="M 65 110 L 65 122" fill="none" stroke="#2a3680" stroke-width="3" stroke-linecap="round"/>
 </svg>


### PR DESCRIPTION
Bump vein stroke from 3 to 6 and drop the bottom-most small vein pair. Keeps bodhi-leaf character (drip-tip stem + paired veins) while making veins legible at favicon size.