### PR TITLE
Beef up footer bodhi + stupa coda; match favicon style

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -118,13 +118,14 @@
       <footer class="site">
         <span>© {{ site.time | date: '%Y' }} {{ site.author }} · Set in Newsreader &amp; Inter</span>
         <span class="ornament" aria-hidden="true">
-          <svg viewBox="0 0 130 130" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
-            <path d="M 65 110 C 45 112 27 98 25 75 C 23 48 41 25 65 15 C 89 25 107 48 105 75 C 103 98 85 112 65 110 Z"/>
-            <path d="M 65 15 L 65 110"/>
-            <path d="M 65 110 L 65 122"/>
-            <path d="M 65 38 Q 53 46 40 53"/><path d="M 65 38 Q 77 46 90 53"/>
-            <path d="M 65 60 Q 51 68 36 75"/><path d="M 65 60 Q 79 68 94 75"/>
-            <path d="M 65 82 Q 54 90 47 96"/><path d="M 65 82 Q 76 90 83 96"/>
+          <svg viewBox="0 0 130 130">
+            <path d="M 65 110 C 45 112 27 98 25 75 C 23 48 41 25 65 15 C 89 25 107 48 105 75 C 103 98 85 112 65 110 Z" fill="#2a3680"/>
+            <g fill="none" stroke="#ffffff" stroke-width="6" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M 65 15 L 65 110"/>
+              <path d="M 65 38 Q 53 46 40 53"/><path d="M 65 38 Q 77 46 90 53"/>
+              <path d="M 65 60 Q 51 68 36 75"/><path d="M 65 60 Q 79 68 94 75"/>
+            </g>
+            <path d="M 65 110 L 65 122" fill="none" stroke="#2a3680" stroke-width="3" stroke-linecap="round"/>
           </svg>
         </span>
         <span><a href="{{ site.orcid }}" rel="noopener">ORCID</a> · <a href="{{ '/feed.xml' | relative_url }}">RSS feed</a></span>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -770,8 +770,8 @@ main pre code { background: none; padding: 0; }
 /* ── Stupa coda (page closer) ─────────────────────────────── */
 .stupa-coda {
   display: block;
-  width: 44px;
-  height: 48px;
+  width: 60px;
+  height: 66px;
   margin: 80px auto 24px;
   background-color: var(--accent-blue);
   -webkit-mask: url('/assets/img/stupa.svg') no-repeat center / contain;
@@ -851,9 +851,8 @@ footer.site {
 footer.site a { color: var(--ink-3); text-decoration: none; }
 footer.site a:hover { color: var(--accent); }
 footer.site .ornament {
-  width: 18px;
-  height: 18px;
-  color: var(--accent-blue);
+  width: 28px;
+  height: 28px;
   opacity: 0.85;
   flex-shrink: 0;
   display: inline-flex;


### PR DESCRIPTION
Page-end ornaments were too subtle.

- Footer bodhi: 18×18 → 28×28, swap outline-stroke for filled-cobalt-with-white-veins (matches favicon)
- Stupa coda: 44×48 → 60×66