### PR TITLE
Unify ornament voice across the site

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -80,7 +80,7 @@
     </script>
     {% endif %}
 
-    <link rel="icon" href="{{ '/assets/img/bodhi.svg' | relative_url }}" type="image/svg+xml">
+    <link rel="icon" href="{{ '/assets/img/favicon.svg' | relative_url }}" type="image/svg+xml">
     <link rel="preconnect" href="https://fonts.bunny.net" crossorigin>
     <link rel="stylesheet" href="https://fonts.bunny.net/css?family=newsreader:400,400i,500,500i,600|inter:400,500,600|jetbrains-mono:400,500&display=swap">
     <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">
@@ -118,14 +118,13 @@
       <footer class="site">
         <span>© {{ site.time | date: '%Y' }} {{ site.author }} · Set in Newsreader &amp; Inter</span>
         <span class="ornament" aria-hidden="true">
-          <svg viewBox="0 0 130 130">
-            <path d="M 65 110 C 45 112 27 98 25 75 C 23 48 41 25 65 15 C 89 25 107 48 105 75 C 103 98 85 112 65 110 Z" fill="#2a3680"/>
-            <g fill="none" stroke="#ffffff" stroke-width="6" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M 65 15 L 65 110"/>
-              <path d="M 65 38 Q 53 46 40 53"/><path d="M 65 38 Q 77 46 90 53"/>
-              <path d="M 65 60 Q 51 68 36 75"/><path d="M 65 60 Q 79 68 94 75"/>
-            </g>
-            <path d="M 65 110 L 65 122" fill="none" stroke="#2a3680" stroke-width="3" stroke-linecap="round"/>
+          <svg viewBox="0 0 130 130" fill="none" stroke="currentColor" stroke-width="4.5" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M 65 110 C 45 112 27 98 25 75 C 23 48 41 25 65 15 C 89 25 107 48 105 75 C 103 98 85 112 65 110 Z"/>
+            <path d="M 65 15 L 65 110"/>
+            <path d="M 65 110 L 65 122"/>
+            <path d="M 65 38 Q 53 46 40 53"/><path d="M 65 38 Q 77 46 90 53"/>
+            <path d="M 65 60 Q 51 68 36 75"/><path d="M 65 60 Q 79 68 94 75"/>
+            <path d="M 65 82 Q 54 90 47 96"/><path d="M 65 82 Q 76 90 83 96"/>
           </svg>
         </span>
         <span><a href="{{ site.orcid }}" rel="noopener">ORCID</a> · <a href="{{ '/feed.xml' | relative_url }}">RSS feed</a></span>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -853,6 +853,7 @@ footer.site a:hover { color: var(--accent); }
 footer.site .ornament {
   width: 28px;
   height: 28px;
+  color: var(--accent-blue);
   opacity: 0.85;
   flex-shrink: 0;
   display: inline-flex;

--- a/assets/img/bodhi.svg
+++ b/assets/img/bodhi.svg
@@ -1,11 +1,11 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 130 130" aria-hidden="true">
-  <path d="M 65 110 C 45 112 27 98 25 75 C 23 48 41 25 65 15 C 89 25 107 48 105 75 C 103 98 85 112 65 110 Z" fill="#2a3680"/>
-  <g fill="none" stroke="#ffffff" stroke-width="6" stroke-linecap="round" stroke-linejoin="round">
-    <path d="M 65 15 L 65 110"/>
-    <path d="M 65 38 Q 53 46 40 53"/>
-    <path d="M 65 38 Q 77 46 90 53"/>
-    <path d="M 65 60 Q 51 68 36 75"/>
-    <path d="M 65 60 Q 79 68 94 75"/>
-  </g>
-  <path d="M 65 110 L 65 122" fill="none" stroke="#2a3680" stroke-width="3" stroke-linecap="round"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 130 130" fill="none" stroke="currentColor" stroke-width="4.5" stroke-linecap="round" stroke-linejoin="round" color="#2a3680" aria-hidden="true">
+  <path d="M 65 110 C 45 112 27 98 25 75 C 23 48 41 25 65 15 C 89 25 107 48 105 75 C 103 98 85 112 65 110 Z"/>
+  <path d="M 65 15 L 65 110"/>
+  <path d="M 65 110 L 65 122"/>
+  <path d="M 65 38 Q 53 46 40 53"/>
+  <path d="M 65 38 Q 77 46 90 53"/>
+  <path d="M 65 60 Q 51 68 36 75"/>
+  <path d="M 65 60 Q 79 68 94 75"/>
+  <path d="M 65 82 Q 54 90 47 96"/>
+  <path d="M 65 82 Q 76 90 83 96"/>
 </svg>

--- a/assets/img/favicon.svg
+++ b/assets/img/favicon.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 130 130" aria-hidden="true">
+  <path d="M 65 110 C 45 112 27 98 25 75 C 23 48 41 25 65 15 C 89 25 107 48 105 75 C 103 98 85 112 65 110 Z" fill="#2a3680"/>
+  <g fill="none" stroke="#ffffff" stroke-width="6" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M 65 15 L 65 110"/>
+    <path d="M 65 38 Q 53 46 40 53"/>
+    <path d="M 65 38 Q 77 46 90 53"/>
+    <path d="M 65 60 Q 51 68 36 75"/>
+    <path d="M 65 60 Q 79 68 94 75"/>
+  </g>
+  <path d="M 65 110 L 65 122" fill="none" stroke="#2a3680" stroke-width="3" stroke-linecap="round"/>
+</svg>

--- a/assets/img/stupa.svg
+++ b/assets/img/stupa.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 110" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" color="#2a3680" aria-hidden="true">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 110" fill="none" stroke="currentColor" stroke-width="4.5" stroke-linecap="round" stroke-linejoin="round" color="#2a3680" aria-hidden="true">
   <path d="M 10 98 L 90 98 L 86 90 L 14 90 Z"/>
   <path d="M 22 90 L 78 90 L 74 84 L 26 84 Z"/>
   <path d="M 26 84 C 26 56 74 56 74 84"/>

--- a/assets/img/wheel.svg
+++ b/assets/img/wheel.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" color="#2a3680" aria-hidden="true">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" fill="none" stroke="currentColor" stroke-width="4.5" stroke-linecap="round" stroke-linejoin="round" color="#2a3680" aria-hidden="true">
   <circle cx="50" cy="50" r="42"/>
   <circle cx="50" cy="50" r="6"/>
   <line x1="50" y1="8" x2="50" y2="92"/>


### PR DESCRIPTION
Systematic pass on Buddhist ornaments — one voice for in-page, separate voice for favicon.

**In-page ornaments** (footer bodhi, stupa coda, dharmachakra, thread bodhi): all flat cobalt silhouettes with bolder geometry. Stroke 2.5 → 4.5 across stupa.svg / wheel.svg / bodhi.svg.

**Favicon** (browser chrome only): kept as filled cobalt + white veins for self-contrast at 16px. Now lives in its own `favicon.svg` to avoid coupling.

- Footer ornament reverts to currentColor outline matching the rest of the site
- `color: var(--accent-blue)` restored on `.ornament`