### PR TITLE
Revert stupa stroke to 2.5 (4.5 was hideous on small details)

### DIFF
--- a/assets/img/stupa.svg
+++ b/assets/img/stupa.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 110" fill="none" stroke="currentColor" stroke-width="4.5" stroke-linecap="round" stroke-linejoin="round" color="#2a3680" aria-hidden="true">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 110" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" color="#2a3680" aria-hidden="true">
   <path d="M 10 98 L 90 98 L 86 90 L 14 90 Z"/>
   <path d="M 22 90 L 78 90 L 74 84 L 26 84 Z"/>
   <path d="M 26 84 C 26 56 74 56 74 84"/>


### PR DESCRIPTION
Stupa-coda was looking blobby at stroke-4.5 because of all the small geometric details (3 stacked umbrella ellipses with ry=2, finial dot, base trapezoids). Reverting just stupa back to 2.5; the new 60x66 element size makes even 2.5 render more substantial than the original 44x48. Bodhi + wheel remain at 4.5 — their geometry is simple enough to handle it.