### PR TITLE
Generate slugified tag pages at /tags/, update tag links, and add mailto on contact page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,8 +12,3 @@ plugins:
 
 feed:
   path: feed.xml
-
-collections:
-  tags:
-    output: true
-    permalink: tags/:path/

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -8,7 +8,7 @@ layout: default
 
   {% if page.tags.size > 0 %}
   <p class="post-tags">
-    {% for tag in page.tags %}<a href="{{ '/tag/' | append: tag | relative_url }}">#{{ tag }}</a> {% endfor %}
+    {% for tag in page.tags %}<a href="{{ '/tags/' | append: (tag | slugify) | append: '/' | relative_url }}">#{{ tag }}</a> {% endfor %}
   </p>
   {% endif %}
 

--- a/_plugins/tags.rb
+++ b/_plugins/tags.rb
@@ -5,21 +5,23 @@ module Jekyll
     def generate(site)
       tags = site.posts.docs.flat_map { |post| post.data['tags'] || [] }.to_set
       tags.each do |tag|
-        site.pages << TagPage.new(site, site.source, tag)
+        tag_slug = Jekyll::Utils.slugify(tag.to_s, mode: "pretty", cased: false)
+        site.pages << TagPage.new(site, site.source, tag, tag_slug)
       end
     end
   end
 
   class TagPage < Page
-    def initialize(site, base, tag)
+    def initialize(site, base, tag, tag_slug)
       @site = site
       @base = base
-      @dir  = File.join('tag', tag)
+      @dir  = File.join('tags', tag_slug)
       @name = 'index.html'
 
       self.process(@name)
       self.read_yaml(File.join(base, '_layouts'), 'tag.html')
       self.data['tag'] = tag
+      self.data['tag_slug'] = tag_slug
       self.data['title'] = "Tag: #{tag}"
     end
   end

--- a/contact.md
+++ b/contact.md
@@ -19,7 +19,7 @@ description: "Get in touch with Aakash Solanki — email, ORCID, Google Scholar.
 </header>
 
 <div class="contact-links">
-  <div class="row"><span class="k">Email</span> mail at aakashsolanki dot net</div>
+  <div class="row"><span class="k">Email</span> <a href="mailto:mail@aakashsolanki.net">mail@aakashsolanki.net</a></div>
   <div class="row"><span class="k">ORCID</span> <a href="https://orcid.org/0000-0002-4879-6998" rel="noopener">0000-0002-4879-6998</a></div>
   <div class="row"><span class="k">Scholar</span> <a href="https://scholar.google.com/citations?user=Y0LLLUMAAAAJ" rel="noopener">Google Scholar</a></div>
 </div>


### PR DESCRIPTION
### Motivation
- Normalize tag URLs to use slugified, lowercased paths under `/tags/` and ensure tag pages are generated at those paths rather than the previous `/tag/` layout.
- Improve contact usability by turning the plaintext email into a clickable `mailto:` link.

### Description
- Update `_plugins/tags.rb` to slugify tag names with `Jekyll::Utils.slugify` and generate `TagPage` instances using the slug, and expose `tag_slug` in page data.
- Change the `TagPage` directory to `File.join('tags', tag_slug)` so tag pages are served under `/tags/<slug>/` and adjust `TagPage` constructor signature accordingly.
- Update `_layouts/post.html` to link tags to `'/tags/' | append: (tag | slugify) | append: '/'` so tag links point to the new slugified paths.
- Add a `mailto:` link for the contact email in `contact.md` and remove the now-unused `collections: tags` block from `_config.yml`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0108e16ac83309f48f28f8e218453)