### PR TITLE
Bump nav touch targets to WCAG 44px minimum

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -106,14 +106,14 @@ a { color: var(--ink); }
 }
 .mast-nav a {
   color: var(--ink-2); text-decoration: none;
-  padding: 12px 4px; position: relative;
+  padding: 16px 8px; position: relative;
   transition: color 0.15s var(--ease);
 }
 .mast-nav a:hover { color: var(--ink); }
 .mast-nav a.active { color: var(--ink); }
 .mast-nav a.active::after {
   content: ''; position: absolute;
-  left: 4px; right: 4px; bottom: -10px;
+  left: 8px; right: 8px; bottom: -14px;
   height: 2px; background: var(--accent-blue);
 }
 
@@ -121,7 +121,7 @@ a { color: var(--ink); }
   background: none;
   border: 1px solid var(--rule);
   color: var(--accent);
-  padding: 4px; border-radius: 3px;
+  padding: 10px; border-radius: 3px;
   display: inline-flex; align-items: center; justify-content: center;
   align-self: center;
   line-height: 0; font-size: 0;


### PR DESCRIPTION
Nav links were ~37x39px and theme toggle 32x32 — both under WCAG's 44x44px touch-target minimum.

- `.mast-nav a` padding: 12px/4px → 16px/8px (45px tall, 47px+ wide)
- Active underline insets shifted to track the new padding (left/right 4→8, bottom -10→-14) so visual position stays the same
- `#theme-toggle` padding: 4 → 10 (final size 46x46)