### PR TITLE
Centre footer leaf to viewport via grid layout

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -842,11 +842,20 @@ footer.site {
   border-top: 1px solid var(--rule);
   font: 400 0.75rem/1.5 var(--sans);
   color: var(--ink-3);
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
   align-items: center;
   gap: 24px;
-  flex-wrap: wrap;
+}
+footer.site > :first-child { justify-self: start; }
+footer.site > :last-child { justify-self: end; }
+@media (max-width: 640px) {
+  footer.site {
+    grid-template-columns: 1fr;
+    text-align: center;
+  }
+  footer.site > :first-child,
+  footer.site > :last-child { justify-self: center; }
 }
 footer.site a { color: var(--ink-3); text-decoration: none; }
 footer.site a:hover { color: var(--accent); }


### PR DESCRIPTION
Footer used `display: flex; justify-content: space-between` — the middle ornament's position depended on side widths, so the leaf drifted right because the copyright text is much longer than the ORCID/RSS links.

Switched to `display: grid; grid-template-columns: 1fr auto 1fr` so the middle column is dead-centred regardless of side widths. Mobile fallback (≤640px) stacks vertically.