### PR TITLE
Stack masthead on narrow viewports

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -85,6 +85,14 @@ a { color: var(--ink); }
   border-bottom: 1px solid var(--ink);
   flex-wrap: wrap; row-gap: 16px;
 }
+@media (max-width: 640px) {
+  .mast {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+  }
+  .mast-nav { margin-left: 0; width: 100%; }
+}
 .mast-title {
   font: 500 italic 1.375rem/1 var(--serif);
   letter-spacing: -0.01em;


### PR DESCRIPTION
Mobile masthead was wrapping awkwardly: title on row 1, then nav ("Work · Contact · 🪔") shoved to the right of row 2 via `margin-left: auto`, leaving empty space on the left and a disconnected feel.

Below 640px, stack the masthead as a column with both title and nav left-aligned. Reads as one unit.