### PR TITLE
Polish mobile masthead nav (right-align + lighter toggle)

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -91,7 +91,12 @@ a { color: var(--ink); }
     align-items: flex-start;
     gap: 12px;
   }
-  .mast-nav { margin-left: 0; width: 100%; }
+  .mast-nav {
+    margin-left: 0;
+    width: 100%;
+    justify-content: flex-end;
+  }
+  #theme-toggle { padding: 6px; }
 }
 .mast-title {
   font: 500 italic 1.375rem/1 var(--serif);


### PR DESCRIPTION
Two adjustments under 640px:

- **(b)** `justify-content: flex-end` on `.mast-nav` so the Work · Contact · toggle row hugs the right edge (mirrors the desktop nav-on-right intuition) instead of packing left with empty space trailing.
- **(c)** Theme toggle padding 10 → 6 on mobile so the bordered box reads as a glyph alongside the plain-text links (~38px square).