### PR TITLE
Footer: replace copyright with last-updated timestamp

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -115,7 +115,7 @@
       </main>
 
       <footer class="site">
-        <span>© {{ site.time | date: '%Y' }} {{ site.author }} · Set in Newsreader &amp; Inter</span>
+        <span>Last updated {{ site.time | date: '%-d %B %Y' }}</span>
         <span class="ornament" aria-hidden="true">
           <svg viewBox="0 0 130 130" fill="none" stroke="currentColor" stroke-width="4.5" stroke-linecap="round" stroke-linejoin="round">
             <path d="M 65 110 C 45 112 27 98 25 75 C 23 48 41 25 65 15 C 89 25 107 48 105 75 C 103 98 85 112 65 110 Z"/>


### PR DESCRIPTION
Drop `© year · Set in Newsreader & Inter` and replace with `Last updated DD Month YYYY` (e.g. "Last updated 27 April 2026"). Updates automatically on every Jekyll rebuild (i.e. every push to main).