### PR TITLE
Fix home block alignment + dark-mode link underlines

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -183,6 +183,12 @@ main ol a:hover {
   color: var(--accent);
   text-decoration-color: var(--accent);
 }
+[data-theme="dark"] main p a,
+[data-theme="dark"] main ul a,
+[data-theme="dark"] main ol a {
+  text-decoration-color: var(--ink-3);
+  text-decoration-thickness: 1.5px;
+}
 
 main h2, main h3, main h4 {
   font-family: var(--serif);
@@ -331,7 +337,7 @@ main pre code { background: none; padding: 0; }
 /* ── Labeled content blocks (home) ────────────────────────── */
 .block {
   display: grid;
-  grid-template-columns: 180px 1fr;
+  grid-template-columns: 220px 1fr;
   gap: 40px;
   padding: 32px 0;
   border-top: 1px solid var(--rule);


### PR DESCRIPTION
Two fixes:

**Alignment** — `.block` label column was 180px, narrow enough that "II. RESEARCH INTERESTS" wrapped to two lines while "III. RECENT NEWS" sat on one. Bumped to 220px so both fit single-line.

**Dark-mode underlines** — links in dark mode used `--rule` (lightness 0.32) for the underline, which was nearly invisible against the dark paper. Overriding in `[data-theme="dark"]` to `--ink-3` (lightness 0.60) and bumping thickness from 1 to 1.5px. Links now read clearly in dark mode while staying subtle.