### PR TITLE
Drop portrait caption on home

### DIFF
--- a/index.md
+++ b/index.md
@@ -11,7 +11,6 @@ layout: default
     <div class="portrait">
       {% if site.logo %}<img src="{{ site.logo | relative_url }}" alt="Portrait of Aakash Solanki" loading="lazy">{% endif %}
     </div>
-    <p class="portrait-cap">In Montreal w/ <a target="_blank" rel="noopener noreferrer" href="https://www.concordia.ca/faculty/ishitatiwary.html">Dr.&nbsp;Ishita Tiwary</a>.</p>
   </div>
 </section>
 


### PR DESCRIPTION
Remove the "In Montreal w/ Dr. Ishita Tiwary" caption under the portrait — cleaner hero, image stands on its own.