### PR TITLE
Swap mono: JetBrains Mono → Special Elite

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -82,7 +82,7 @@
 
     <link rel="icon" href="{{ '/assets/img/favicon.svg' | relative_url }}" type="image/svg+xml">
     <link rel="preconnect" href="https://fonts.bunny.net" crossorigin>
-    <link rel="stylesheet" href="https://fonts.bunny.net/css?family=newsreader:400,400i,500,500i,600|inter:400,500,600|jetbrains-mono:400,500&display=swap">
+    <link rel="stylesheet" href="https://fonts.bunny.net/css?family=newsreader:400,400i,500,500i,600|inter:400,500,600|special-elite:400&display=swap">
     <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">
   </head>
   <body>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -13,7 +13,7 @@
 
   --serif: "Newsreader", Georgia, serif;
   --sans:  "Inter", system-ui, -apple-system, sans-serif;
-  --mono:  "JetBrains Mono", ui-monospace, Menlo, monospace;
+  --mono:  "Special Elite", "Courier Prime", ui-monospace, Menlo, monospace;
 
   --fs-display: clamp(2.75rem, 6.5vw, 5.25rem);
   --fs-title:   clamp(2rem, 4.5vw, 3.25rem);


### PR DESCRIPTION
Move the metadata typeface from programmer mono to typewriter mono. Newsreader-serif + Special Elite pairs *book* with *field notes* — fitting register for ethnography (the published text and the notebook behind it).

Touches:
- Bunny Fonts request: `jetbrains-mono` → `special-elite`
- `--mono` token: `Special Elite, Courier Prime, ui-monospace…` (Courier Prime fallback keeps typewriter character if Special Elite fails to load)

All metadata surfaces flip via `var(--mono)`: kicker labels, year markers, DOIs, code blocks, footer timestamp.