### PR TITLE
A11y: semantic h2 section headings + brighter light-mode link underlines

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -174,7 +174,7 @@ main ol a {
   text-decoration: underline;
   text-underline-offset: 3px;
   text-decoration-thickness: 1px;
-  text-decoration-color: var(--rule);
+  text-decoration-color: var(--ink-3);
   transition: color 0.15s var(--ease), text-decoration-color 0.15s var(--ease);
 }
 main p a:hover,
@@ -186,7 +186,6 @@ main ol a:hover {
 [data-theme="dark"] main p a,
 [data-theme="dark"] main ul a,
 [data-theme="dark"] main ol a {
-  text-decoration-color: var(--ink-3);
   text-decoration-thickness: 1.5px;
 }
 
@@ -349,6 +348,7 @@ main pre code { background: none; padding: 0; }
   letter-spacing: 0.15em; text-transform: uppercase;
   color: var(--ink-3);
   padding-top: 4px;
+  margin: 0;
 }
 .block .body { max-width: 65ch; }
 .block .body > :first-child { margin-top: 0; }

--- a/caste-technoscience.md
+++ b/caste-technoscience.md
@@ -22,7 +22,7 @@ description: "An ongoing collaborative project convening interdisciplinary conve
 </header>
 
 <div class="block">
-  <div class="label">The question</div>
+  <h2 class="label">The question</h2>
   <div class="body">
     <p>Despite its importance as an analytical category in the social life of South Asia and its diasporas, caste has remained relatively undertheorized in the social studies of science and technology. Where caste does appear in STS, it has most often figured as an identity category rather than as a sociotechnical formation in its own right.</p>
     <p>This project asks: what happens when we reframe the study of caste <em>as</em> a study of technoscience? What conceptual and methodological toolkits does such a move require? How are caste and technoscience intertwined — historically, infrastructurally, materially? What does it mean to approach caste as a technoscientific project of domination and subjugation, or as a form of media that mediates sociotechnical relations?</p>
@@ -30,7 +30,7 @@ description: "An ongoing collaborative project convening interdisciplinary conve
 </div>
 
 <div class="block">
-  <div class="label">Convenings</div>
+  <h2 class="label">Convenings</h2>
   <div class="body">
     <p><strong>2021 · 4S (virtual) — <em><a target="_blank" rel="noopener noreferrer" href="https://4sonline.org/news_manager.php?page=29528">Caste as/of Technoscience</a></em>.</strong> A four-session open panel inaugurating sustained attention to caste as a generative analytical framework for STS. The panel drew together anthropologists, historians, media studies scholars, and information scientists working across empire, colonialism, and postcolonial technoscience. Conversations from this panel are taking shape as a journal special issue.</p>
     <p><strong>2025 · 4S Seattle — <em><a target="_blank" rel="noopener noreferrer" href="https://www.4sonline.org/accepted_open_panels_seattle.php">Caste as/of Technoscience II</a></em>.</strong> Advanced the 2021 work by identifying a limit within much critical scholarship: that the field often remains organized around opposition to Brahmin hegemony, which inadvertently keeps Brahminism at the center. The 2025 panel began the harder task of thinking both technoscience and caste <em>without</em> centering Brahminism at all.</p>

--- a/digital-rights-activism-dialogues.md
+++ b/digital-rights-activism-dialogues.md
@@ -21,7 +21,7 @@ description: "A King's College London online dialogue series on digital rights a
 </header>
 
 <div class="block">
-  <div class="label">The question</div>
+  <h2 class="label">The question</h2>
   <div class="body">
     <p>Even as the hype over the promises and perils of large language models, the increasing financialization of everyday life, digital public infrastructures, and e-currency engulfs the zeitgeist, this series steers conversations away from corporation-dominated discourses toward transnational activist energies across the Global South.</p>
     <p>The digital-rights activist movement contains multitudes &mdash; civic hackers, responsible-data activists, right-to-information advocates, civil-rights lawyers, anti-caste activists, data feminists, anti-national-ID and privacy activists, leading curators of the archival commons. Race, caste, ethnicity, gender, and sexuality have filtered the often invisible labour of this work. These movements are scattered in their respective publics and goalposts but are marked by potential solidarities against capitalist surveillance, automated injustice, and often state-enabled cyber violence.</p>
@@ -29,14 +29,14 @@ description: "A King's College London online dialogue series on digital rights a
 </div>
 
 <div class="block">
-  <div class="label">Format</div>
+  <h2 class="label">Format</h2>
   <div class="body">
     <p>Each conversation pairs two or more activists or activism-adjacent academics speaking to a particular clustering of digital rights across regional geographies of the Global South, moderated by an academic working in an adjacent research area. Each speaker offers a historical reflection on how digital-rights activism emerged in a particular regional site of collective struggle &mdash; tracing the arc from lawfare and authoritarian displeasure to crony-capitalist capture and fascist techno-solutionism &mdash; and reflects on what this has meant for an immediate struggle: a lawsuit, rights advocacy, coalition, movement-building.</p>
   </div>
 </div>
 
 <div class="block">
-  <div class="label">Themes</div>
+  <h2 class="label">Themes</h2>
   <div class="body">
     <p><strong>Social media and cyber security.</strong> Histories of digital-rights mobilisation, moderation, and de-policing; cyber-harassment formulations re-centred on caste, communal, and gendered violence; the social, economic, and psychological harms incurred by content moderators training large language models on behalf of tech companies.</p>
     <p><strong>Social services.</strong> Cash transfers and apps that necessitate the &ldquo;performance evaluation&rdquo; of health workers; the entry of philanthropic actors into welfare provisioning under post-2000 conditions; debates on food and health security and the burdens placed on data workers.</p>
@@ -46,7 +46,7 @@ description: "A King's College London online dialogue series on digital rights a
 </div>
 
 <div class="block">
-  <div class="label">Hosts and partners</div>
+  <h2 class="label">Hosts and partners</h2>
   <div class="body">
     <p>Hosted by the <a target="_blank" rel="noopener noreferrer" href="https://www.kcl.ac.uk/history">History Department at King&rsquo;s College London</a> in collaboration with the Labor Tech Network, the King&rsquo;s India Institute, the Africa Leadership Centre, the Brazil Institute, and the Menzies Australia Institute.</p>
     <p>Full series and upcoming dialogues: <a target="_blank" rel="noopener noreferrer" href="https://www.kcl.ac.uk/events/series/digital-rights-activism-dialogues">kcl.ac.uk/events/series/digital-rights-activism-dialogues</a>.</p>

--- a/index.md
+++ b/index.md
@@ -15,7 +15,7 @@ layout: default
 </section>
 
 <div class="block">
-  <div class="label">I. Biography</div>
+  <h2 class="label">I. Biography</h2>
   <div class="body">
     <p>Aakash Solanki is a PhD candidate in <a target="_blank" rel="noopener noreferrer" href="https://www.anthropology.utoronto.ca/people/directories/graduate-students/aakash-solanki">Anthropology</a> and <a target="_blank" rel="noopener noreferrer" href="https://munkschool.utoronto.ca/ai/centre-south-asian-studies">South Asian Studies</a> at the University of Toronto. His research sits at the intersection of the anthropology of the state, science and technology studies, and the historical study of statistics and computing. He has worked on the collection, classification, and management of information in colonial and postcolonial India. In addition to prior training in computer science, he has worked in government agencies in the US and India on data science projects in education, health, and skill development at municipal, state, and federal levels.</p>
     <p>His dissertation, <em>Governing Indeterminately: An Ethnography of Technopopulism from India</em>, draws on long-term fieldwork in Indian state and central bureaucracies to examine how digital infrastructures mediate development, statecraft, and fiscal federal relations. The research is funded by the International Development Research Centre (IDRC) and the Wenner-Gren Foundation for Anthropological Research.</p>
@@ -24,7 +24,7 @@ layout: default
 </div>
 
 <div class="block">
-  <div class="label">II. Research interests</div>
+  <h2 class="label">II. Research interests</h2>
   <div class="body">
     <ul class="bullets">
       <li><span class="num">01</span><span>Colonial and postcolonial histories of statistics and statecraft</span></li>
@@ -37,7 +37,7 @@ layout: default
 </div>
 
 <div class="block">
-  <div class="label">III. Recent news</div>
+  <h2 class="label">III. Recent news</h2>
   <div class="body">
     <ul class="bullets news">
       <li><span class="num">Apr 2026</span><span>Presentation at the Graduate Workshop, University of Toronto: &ldquo;Constitutive Incompetence: Caste, Expertise, and the Indian State.&rdquo;</span></li>

--- a/libraries.md
+++ b/libraries.md
@@ -27,7 +27,7 @@ description: "An inquiry into libraries as sites of democratic encounter, anchor
 </figure>
 
 <div class="block">
-  <div class="label">Why libraries</div>
+  <h2 class="label">Why libraries</h2>
   <div class="body">
     <p>Public-library spending is, on the surface, an accounting question. Beneath it sits a political one. John Dewey understood democracy not as voting procedures but as <em>associated living</em> &mdash; the cultivation of shared experience, cooperative inquiry, and communication across difference. B.&nbsp;R.&nbsp;Ambedkar, deeply influenced by Dewey, insisted democracy required not just political equality but social transformation: a mode of associated living, of conjoint communicated experience. Ambedkar was clear-eyed that without fraternity &mdash; which he reconceived through the Buddhist principle of <em>maitri</em>, loving-kindness or universal friendship &mdash; liberty and equality remain hollow, and democracy slides into majoritarianism.</p>
     <p>Libraries are one of the few public institutions where associated living must be enacted bodily: who sits where, who touches which books, whose literacies are recognised as knowledge, who serves whom, who feels welcome to stay. They are flashpoints &mdash; sites where caste hierarchy, gender exclusion, capital&rsquo;s infrastructural power, and majoritarian control materialise and collide with the democratic aspiration of the public good. To ask what the Indian state spends on its libraries is therefore to ask what its democracy is willing to underwrite &mdash; whether the conditions for <em>maitri</em> are being financed at all.</p>
@@ -36,7 +36,7 @@ description: "An inquiry into libraries as sites of democratic encounter, anchor
 </div>
 
 <div class="block">
-  <div class="label">The question</div>
+  <h2 class="label">The question</h2>
   <div class="body">
     <p>Public libraries are unevenly funded, unevenly spoken about, and unevenly attended to as a public good. India spends a fraction of what comparable countries spend on public libraries; even within India, spending is concentrated in a few states while most receive almost nothing from the central pot. The first step in changing that is to make the numbers legible.</p>
     <p>This project is a primer and a tracker. It pulls public-finance figures from state and central sources, benchmarks them against international peers, and presents a state-by-state view of what is spent and where it goes. The work sits inside the broader research and advocacy programme of the <a target="_blank" rel="noopener noreferrer" href="https://www.fln.org.in">Free Libraries Network, India and South Asia</a> &mdash; a coalition of more than 260 free libraries across 28 states and union territories.</p>
@@ -44,7 +44,7 @@ description: "An inquiry into libraries as sites of democratic encounter, anchor
 </div>
 
 <div class="block">
-  <div class="label">What the data shows</div>
+  <h2 class="label">What the data shows</h2>
   <div class="body">
     <p><strong>Per-capita spend.</strong> India&rsquo;s public-library expenditure works out to about &#8377;15.30 per person per year (2020&ndash;21). That is roughly 232 times less than the United States in nominal terms, and around 80 times less than Finland after adjusting for purchasing power. Goa, the highest-spending Indian state, reaches about &#8377;140 per capita &mdash; still well below UK levels. <em>Source: IIHS, <a target="_blank" rel="noopener noreferrer" href="https://iihs.co.in/knowledge-gateway/what-is-the-per-capita-expenditure-on-public-libraries-in-india-an-empirical-analysis/">What is the per-capita expenditure on public libraries in India?</a></em></p>
     <p><strong>Library acts without library money.</strong> Several Indian states with library legislation spend below the national average; legislation alone does not guarantee funding. <em>Sources: Vidhi Centre for Legal Policy, <a target="_blank" rel="noopener noreferrer" href="https://vidhilegalpolicy.in/research/putting-the-public-back-in-public-libraries/">Putting the Public back in Public Libraries</a>; IIHS, <a target="_blank" rel="noopener noreferrer" href="https://iihs.co.in/knowledge-gateway/a-policy-review-of-public-libraries-in-india/">A Policy Review of Public Libraries in India</a>.</em></p>
@@ -53,7 +53,7 @@ description: "An inquiry into libraries as sites of democratic encounter, anchor
 </div>
 
 <div class="block">
-  <div class="label">A people&rsquo;s policy</div>
+  <h2 class="label">A people&rsquo;s policy</h2>
   <div class="body">
     <p>The Free Libraries Network has drafted a <em>People&rsquo;s National Library Policy 2024</em> &mdash; an independent civil-society policy framework calling for a right to read, free public libraries with books and trained librarians, integration of school and public libraries, and a financial-instrument architecture at the state level. The policy has been endorsed by the International Federation of Library Associations and Institutions (IFLA), the Dalit Bahujan Resource Centre, the National Campaign on Dalit Human Rights, and HarperCollins India, among others.</p>
     <p>FLN&rsquo;s coalition includes <a target="_blank" rel="noopener noreferrer" href="https://www.thecommunitylibraryproject.org/">The Community Library Project</a> in Delhi NCR and the Bansa Community Library in Uttar Pradesh, alongside many others.</p>
@@ -65,7 +65,7 @@ description: "An inquiry into libraries as sites of democratic encounter, anchor
 </figure>
 
 <div class="block">
-  <div class="label">The dashboard</div>
+  <h2 class="label">The dashboard</h2>
   <div class="body">
     <p>The interactive tracker is the working face of this project &mdash; sortable, downloadable, and updated as new state-level data becomes available.</p>
     <p style="margin-top: 18px;"><a href="/freelibraries4all/" class="cta">Open the India Library Spend Tracker &rarr;</a></p>

--- a/research.md
+++ b/research.md
@@ -22,7 +22,7 @@ description: "An ethnography of governance after planning — regional inequalit
 </header>
 
 <div class="block">
-  <div class="label">The question</div>
+  <h2 class="label">The question</h2>
   <div class="body">
     <p>For most of the twentieth century, the developmental authority of postcolonial states rested on a particular epistemic claim — that the state could know, through statistics, surveys, and resource assessments, the social and economic processes it sought to govern. By the early twenty-first century, that claim no longer holds steady. National statistical infrastructures have lost authority and coverage; new digital infrastructures have not yet consolidated reliability.</p>
     <p>The dissertation pursues what it means to govern through this interregnum. Drawing on three years of fieldwork and archival research reaching back to the postcolonial planning institutions of the 1950s, it argues that contemporary modes of governing do not retreat from technical infrastructure when its epistemic ground gives way. Instead, they redeploy it for other purposes — to generate political rhythm, competitive community, and the spectacular performance of governance improvement.</p>
@@ -95,7 +95,7 @@ description: "An ethnography of governance after planning — regional inequalit
 </figure>
 
 <div class="block">
-  <div class="label">Method</div>
+  <h2 class="label">Method</h2>
   <div class="body">
     <p>An ethnography of elites &mdash; bureaucratic offices, vendor meetings, consultant deliverables, internal review forums &mdash; rather than of those subjected to them. Participant-observation alongside policy consultants and the technical staff who build governance dashboards; long-form interviews with central- and state-cadre officials; document analysis across cabinet resolutions, programme guidelines, and digital portals; archival work in national and state collections. The project moves between offices and districts, between papers tabled in parliament and forms filled at the block level &mdash; but the analytic centre stays with the people writing, monitoring, and reviewing policy.</p>
   </div>
@@ -111,7 +111,7 @@ description: "An ethnography of governance after planning — regional inequalit
 </figure>
 
 <div class="block">
-  <div class="label">Earlier work</div>
+  <h2 class="label">Earlier work</h2>
   <div class="body">
     <p>Two strands precede the dissertation. A Master&rsquo;s thesis at the <a target="_blank" rel="noopener noreferrer" href="https://www.uchicago.edu">University of Chicago</a> (2014, advised by <a target="_blank" rel="noopener noreferrer" href="https://anthropology.uchicago.edu/people/john-d-kelly">John D. Kelly</a>) on the Criminal Tribes Act and police practice in British India, 1871&ndash;1927, argued against scholarship that read the Act as a uniform homogenising apparatus, drawing on police manuals to show classification at the level of practice as variable, multidimensional, and uneven. The thesis pre-empts contemporary debates on AI-driven facial recognition, carcerality, and predictive policing &mdash; tracing how nineteenth-century apparatuses already operated through racialised, hereditary classification of populations marked for surveillance.</p>
     <p>A stint on the City of Chicago&rsquo;s Smart Cities team (2014&ndash;15) contributed to a <a target="_blank" rel="noopener noreferrer" href="https://chicago.github.io/food-inspections-evaluation/">predictive model for food inspections</a> used by the city&rsquo;s Department of Public Health. The dissertation inherits both threads &mdash; the suspicion of homogenising classifications and a working knowledge of what predictive systems actually do inside a state apparatus.</p>

--- a/states-startups-capital.md
+++ b/states-startups-capital.md
@@ -21,7 +21,7 @@ description: "A joint inquiry with Sandeep Mertia and Nafis Hasan into mobile ap
 </header>
 
 <div class="block">
-  <div class="label">The question</div>
+  <h2 class="label">The question</h2>
   <div class="body">
     <p>Mobile apps are relationally embedded in socio-technical practices that not only reproduce older connections but constitute new ones. They offer a different configuration of software architecture and re-arrange the spatial and temporal dimensions of social life. Like other software, but far more intensely, apps both <em>congeal</em> and <em>conceal</em> power, labour, hierarchy, and inequity in and through their democratic sheen.</p>
     <p>How do apps emerge and circulate not just as the dominant forms of products and services in the digital economy, but as the form of the technological state and its relation with people? How does the logic of mobility and agility that characterises information on apps sit with the rigidity and hierarchy of power-vested institutions? States, for instance, are peripatetic but not mobile. Yet, the charisma of apps &mdash; often linked with other social media or messaging platforms &mdash; is making its mark on the state across the globe.</p>
@@ -29,7 +29,7 @@ description: "A joint inquiry with Sandeep Mertia and Nafis Hasan into mobile ap
 </div>
 
 <div class="block">
-  <div class="label">The empirical opening</div>
+  <h2 class="label">The empirical opening</h2>
   <div class="body">
     <p>Since 2013, the Indian government has put up over 900 apps in its public app store, offering a plethora of opportunities to study the biopolitical aims of apps&rsquo; sociality. Apps that promise easy appointments in public hospitals turn out to be conduits for stealing people&rsquo;s identity numbers; apps to deliver welfare entitlements stall under the weight of broken systems; apps for performance evaluation reshape what frontline work even is. We propose to think about the sociality of apps in state projects not only through their avowed outcomes but through their myriad effects.</p>
     <p>State agencies, in many places, make apps faster than they deliver public services. Even as the affordances and immediacy of apps produce instant data, broken systems stall the interpretive effects of big data. The inquiry sits with this pairing &mdash; the productivity of app-form, and its limits.</p>
@@ -37,14 +37,14 @@ description: "A joint inquiry with Sandeep Mertia and Nafis Hasan into mobile ap
 </div>
 
 <div class="block">
-  <div class="label">Lines of analysis</div>
+  <h2 class="label">Lines of analysis</h2>
   <div class="body">
     <p>What does app use by state agents tell us about the materiality and performativity of the state &mdash; its legitimacy in law and its monopoly over power in society? What does a material analysis of these forms reveal about the network of relations through which contemporary techno-states are constituted in relation to the global digital economy? And how does the circulatory matrix of new discursive forms, practices, and artefacts constitute subjects in relation to states?</p>
   </div>
 </div>
 
 <div class="block">
-  <div class="label">Convenings</div>
+  <h2 class="label">Convenings</h2>
   <div class="body">
     <p><strong>2022 &middot; 4S Cholula &mdash; <em>Government of, as, and by App(s)</em>.</strong> An open panel reflecting on STS themes of governance and public policy alongside digital infrastructures and their effects on the network of relations that constitutes state power. Co-organised with Sandeep Mertia and Nafis Hasan.</p>
   </div>

--- a/teaching.md
+++ b/teaching.md
@@ -22,14 +22,14 @@ description: "Undergraduate courses designed and taught as instructor of record 
 </header>
 
 <div class="block">
-  <div class="label">Approach</div>
+  <h2 class="label">Approach</h2>
   <div class="body">
     <p>I came up through a science and engineering education in India — a didactic culture in which knowledge moves one way, from text to student, through memorisation and the regurgitation of accepted facts. Graduate training in the humanities and social sciences in the United States and Canada introduced me to a more Socratic mode, in which texts are not containers of information but live documents that get activated differently depending on the context in which they are read. I teach at the seam between those two cultures of learning, and try to make the seam visible to students. The aim is to move them away from a model of &ldquo;downloading facts&rdquo; from a teacher-as-authority toward an understanding of knowledge in the humanities and social sciences as something produced through critical engagement, juxtaposition, and re-reading.</p>
   </div>
 </div>
 
 <div class="block">
-  <div class="label">Practice</div>
+  <h2 class="label">Practice</h2>
   <div class="body">
     <p>The week-to-week mechanics follow from this. Short writing prompts push students past summary into critically assessing, contrasting, and juxtaposing claims within and across texts. Collaborative annotation in <a target="_blank" rel="noopener noreferrer" href="https://web.hypothes.is/">hypothes.is</a> makes reading a shared, visible practice rather than a private one — and lets me see methodologically where students need more support. Activity-based exercises put the object of critique in students&rsquo; hands before the secondary literature does: reading an actual RCT paper alongside the development-studies critique of RCTs; working through &mdash; or building &mdash; a small dashboard in class before turning to the politics of dashboards as a media object. Large language models enter the syllabus as objects of critical reading: students compare a machinic &ldquo;reading&rdquo; of a text against an interpretive one and learn what each kind of reading can and cannot do. Across a term, the arc is descriptive to interpretive.</p>
   </div>

--- a/utdevsem.md
+++ b/utdevsem.md
@@ -20,7 +20,7 @@ description: "Concept note for the 2018-2019 Development Seminar series at the U
 </header>
 
 <div class="block">
-  <div class="label">Concept note · 2018–2019</div>
+  <h2 class="label">Concept note · 2018–2019</h2>
   <div class="body">
     <p>Guest speakers bring innovative research investigating migration, infrastructure, livelihoods, gender, and politics. In the 2017–2018 academic year, we hosted development studies scholars working at the intersection of gender and foreign aid, with emphasis on aid-giving institutions in the Global North — CIDA in Canada, USAID in the US.</p>
     <p>The 2018–2019 series takes off from where we left in March: the politics of numbers behind development. Numbers — or to use a more current term, data (usually connoting numerical data) — are ubiquitous. Business organisations have talked for years about &ldquo;data as the new oil&rdquo;; governments, transnational aid agencies, Bretton Woods organisations, and others have turned to carefully exploring &ldquo;data&rdquo; as the new twenty-first century asset. The focus on numerical data — Big Data, machine learning, artificial intelligence — as the bedrock of informed policy and business decision-making is instrumental to understanding emerging changes in development practice.</p>


### PR DESCRIPTION
Two WCAG 2.1 AA fixes from the accessibility audit:

**1.3.1 Info and Relationships** — Section labels (`.block .label`) were styled headings rendered as `<div>`. Screen readers couldn't navigate them. Converted all 23 instances across 10 pages to `<h2 class="label">`. Added `margin: 0` to `.block .label` to override default h2 margins; existing font/color rules (sans uppercase, ink-3) carry the visual style as before.

**1.4.1 Use of Color (polish)** — Light-mode body link underlines used `--rule` (~1.7:1 against cream paper). Switched to `--ink-3` (~3.5:1), matching the dark-mode treatment. Removed the now-redundant color override in `[data-theme="dark"]` block.

No visual change to anyone with sighted vision in light mode beyond slightly more visible underlines.