### PR TITLE
Add per-publication anchor IDs + hover permalink affordance

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -485,8 +485,34 @@ main pre code { background: none; padding: 0; }
   grid-template-columns: 80px 1fr auto;
   gap: 24px;
   align-items: baseline;
+  position: relative;
+  scroll-margin-top: 80px;
 }
 .pub:last-of-type { border-bottom: 1px solid var(--rule); }
+.pub-anchor {
+  position: absolute;
+  left: -1.4em;
+  top: 22px;
+  font: 400 1rem/1 var(--mono);
+  color: var(--ink-3);
+  text-decoration: none;
+  opacity: 0;
+  transition: opacity 0.15s var(--ease), color 0.15s var(--ease);
+}
+.pub:hover .pub-anchor,
+.pub-anchor:focus-visible { opacity: 0.55; }
+.pub-anchor:hover { color: var(--accent-blue); opacity: 1; }
+.pub:target {
+  background: color-mix(in oklch, var(--accent-blue) 9%, transparent);
+  border-radius: 4px;
+  padding-left: 12px;
+  padding-right: 12px;
+  margin-left: -12px;
+  margin-right: -12px;
+}
+@media (max-width: 820px) {
+  .pub-anchor { display: none; }
+}
 .pub .yr {
   font: 500 0.8125rem/1.2 var(--mono);
   color: var(--accent);

--- a/publications.md
+++ b/publications.md
@@ -23,7 +23,7 @@ description: "Publications by Aakash Solanki: public scholarship, interdisciplin
 
 <h2 class="sect"><span class="n">§ 01</span>Public scholarship</h2>
 
-<div class="pub">
+<div class="pub" id="solanki-2025-express">
   <span class="yr">2025</span>
   <div class="main">
     <p class="title"><a target="_blank" rel="noopener noreferrer" href="https://indianexpress.com/article/opinion/columns/india-start-ups-not-lacking-innovation-imagination-9974148/">India&rsquo;s start-ups are not lacking innovation but imagination</a></p>
@@ -32,9 +32,10 @@ description: "Publications by Aakash Solanki: public scholarship, interdisciplin
     <p class="note">With <a target="_blank" rel="noopener noreferrer" href="https://www.stevens.edu/profile/smertia">Sandeep Mertia</a>.</p>
   </div>
   <span class="tags">Op-ed</span>
+  <a class="pub-anchor" href="#solanki-2025-express" aria-label="Permalink to this publication">#</a>
 </div>
 
-<div class="pub">
+<div class="pub" id="solanki-2018-culanth">
   <span class="yr">2018</span>
   <div class="main">
     <p class="title"><a target="_blank" rel="noopener noreferrer" href="https://culanth.org/fieldsights/suddenly-statistics">Suddenly, Statistics?</a></p>
@@ -42,11 +43,12 @@ description: "Publications by Aakash Solanki: public scholarship, interdisciplin
     <p class="blurb">On the dissonance between anthropology&rsquo;s general suspicion of numbers and the discipline&rsquo;s sudden turn to statistics in confronting its own precarity.</p>
   </div>
   <span class="tags">Essay</span>
+  <a class="pub-anchor" href="#solanki-2018-culanth" aria-label="Permalink to this publication">#</a>
 </div>
 
 <h2 class="sect"><span class="n">§ 02</span>Interdisciplinary scholarly output</h2>
 
-<div class="pub">
+<div class="pub" id="solanki-2026-chi">
   <span class="yr">2026</span>
   <div class="main">
     <p class="title"><a target="_blank" rel="noopener noreferrer" href="https://doi.org/10.1145/3772318.3791530">&ldquo;Studying Up&rdquo; through Digital Ethnography: The Case of Conservative Caste Enclaves</a></p>
@@ -55,18 +57,20 @@ description: "Publications by Aakash Solanki: public scholarship, interdisciplin
     <p class="note">With <a target="_blank" rel="noopener noreferrer" href="https://ischool.utoronto.ca/student-profile/ashique-ali-thuppilikkat/">Ashique Ali Thuppilikkat</a> and <a target="_blank" rel="noopener noreferrer" href="https://ischool.utoronto.ca/faculty-profile/priyank-chandra/">Priyank Chandra</a> (both at <a target="_blank" rel="noopener noreferrer" href="https://www.streetlab.tech/">Street Lab</a>).</p>
   </div>
   <span class="tags">CHI</span>
+  <a class="pub-anchor" href="#solanki-2026-chi" aria-label="Permalink to this publication">#</a>
 </div>
 
-<div class="pub">
+<div class="pub" id="solanki-cscw-everyday">
   <span class="yr">—</span>
   <div class="main">
     <p class="title">Everyday Data Science: Notes from the Public Sector in India.</p>
     <p class="venue">ACM Conference on Computer-Supported Cooperative Work and Social Computing (CSCW).</p>
   </div>
   <span class="tags">R&amp;R</span>
+  <a class="pub-anchor" href="#solanki-cscw-everyday" aria-label="Permalink to this publication">#</a>
 </div>
 
-<div class="pub">
+<div class="pub" id="solanki-2016-epic">
   <span class="yr">2016</span>
   <div class="main">
     <p class="title"><a target="_blank" rel="noopener noreferrer" href="https://doi.org/10.1111/1559-8918.2016.01107">Going Ethno in the Indian Bureaucracy</a></p>
@@ -75,11 +79,12 @@ description: "Publications by Aakash Solanki: public scholarship, interdisciplin
     <p class="note">With <a target="_blank" rel="noopener noreferrer" href="https://www.linkedin.com/in/sarveshtewari/">Sarvesh Tewari</a>.</p>
   </div>
   <span class="tags">EPIC</span>
+  <a class="pub-anchor" href="#solanki-2016-epic" aria-label="Permalink to this publication">#</a>
 </div>
 
 <h2 class="sect"><span class="n">§ 03</span>Peer-reviewed journal articles</h2>
 
-<div class="pub">
+<div class="pub" id="solanki-2019-south-asia">
   <span class="yr">2019</span>
   <div class="main">
     <p class="title"><a target="_blank" rel="noopener noreferrer" href="https://doi.org/10.1080/00856401.2019.1603262">Management of Performance and Performance of Management: Getting to Work on Time in the Indian Bureaucracy</a></p>
@@ -87,28 +92,31 @@ description: "Publications by Aakash Solanki: public scholarship, interdisciplin
     <p class="blurb">How an Aadhaar-enabled biometric attendance system in a North Indian bureaucracy was partially circumvented by the staff it was meant to discipline — producing a performance of management rather than its substance.</p>
   </div>
   <span class="tags">Article</span>
+  <a class="pub-anchor" href="#solanki-2019-south-asia" aria-label="Permalink to this publication">#</a>
 </div>
 
-<div class="pub">
+<div class="pub" id="solanki-under-review">
   <span class="yr">—</span>
   <div class="main">
     <p class="title">Three manuscripts currently under review at peer-reviewed journals.</p>
     <p class="note">One manuscript in preparation: <em>Digitalization in a Different Key: A History of Management of Information Systems.</em></p>
   </div>
   <span class="tags">In progress</span>
+  <a class="pub-anchor" href="#solanki-under-review" aria-label="Permalink to this publication">#</a>
 </div>
 
 <h2 class="sect"><span class="n">§ 04</span>Book chapters</h2>
 
-<div class="pub">
+<div class="pub" id="solanki-forthcoming-women-policy">
   <span class="yr">Forth.</span>
   <div class="main">
     <p class="title">&ldquo;Is it really possible?&rdquo; Women public policy professionals and the promises and perils of a &ldquo;guerrilla&rdquo; data science.</p>
   </div>
   <span class="tags">Forthcoming</span>
+  <a class="pub-anchor" href="#solanki-forthcoming-women-policy" aria-label="Permalink to this publication">#</a>
 </div>
 
-<div class="pub">
+<div class="pub" id="solanki-2020-untidy-data">
   <span class="yr">2020</span>
   <div class="main">
     <p class="title"><a target="_blank" rel="noopener noreferrer" href="https://networkcultures.org/blog/publication/lives-of-data-essays-on-computational-cultures-from-india/">Untidy Data: Spreadsheet Practices in the Indian Bureaucracy</a></p>
@@ -117,6 +125,7 @@ description: "Publications by Aakash Solanki: public scholarship, interdisciplin
     <p class="note"><a target="_blank" rel="noopener noreferrer" href="https://player.fm/series/new-books-in-technology-2421470/sandeep-mertia-lives-of-data-essays-on-computational-cultures-from-india-institute-of-networked-cultures-2020">→ Podcast discussion</a></p>
   </div>
   <span class="tags">Chapter</span>
+  <a class="pub-anchor" href="#solanki-2020-untidy-data" aria-label="Permalink to this publication">#</a>
 </div>
 
 <div class="stupa-coda" role="presentation"></div>


### PR DESCRIPTION
Each entry on /publications/ gets a stable `id` so it can be deep-linked. Convention: `solanki-YYYY-venue` (or descriptor for forthcoming/in-progress).

**Why:**
- Cite a specific paper in an email/syllabus: `aakashsolanki.net/publications#solanki-2026-chi`
- Backlinks from other sites land directly on the right entry
- :target highlight gives a soft cobalt tint when arrived at via deep link

**UX:**
- A subtle `#` appears on hover to the left of each entry — click to grab the deep-link URL from the address bar (or right-click → Copy Link)
- Hidden on mobile (≤820px) since hover-only affordances don't help touch users
- `scroll-margin-top: 80px` on `.pub` so anchored entries land cleanly

**Try it:** [#solanki-2026-chi](https://aakashsolanki.net/publications#solanki-2026-chi) after deploy.