### PR TITLE
Maintenance: enable jekyll-sitemap + document plugin limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,13 @@ of Google Fonts).
 - `_posts/` — blog posts (filename: `YYYY-MM-DD-slug.md`)
 - `_drafts/` — unpublished drafts
 - `_layouts/` — page templates
-- `_plugins/tags.rb` — generates tag pages
+- `_plugins/tags.rb` — generates tag pages (⚠️ inactive on production: GitHub Pages legacy build mode does not run user plugins. To activate, migrate the build to GitHub Actions. Layout, generator, and `tag.html` are kept in place as scaffolding for that migration.)
 
 ## Deploy
 
-GitHub Pages builds from `main`. Every push to `main` deploys.
+GitHub Pages builds from `main` in legacy Jekyll mode. Every push to `main` deploys.
+
+Plugins active on production are limited to the GitHub Pages whitelist: `jekyll-feed`, `jekyll-seo-tag`, `jekyll-sitemap`. To use any plugin outside that list (e.g. `jekyll-last-modified-at`, the in-repo `_plugins/tags.rb`), the site needs to migrate from "Deploy from a branch" to a custom GitHub Actions workflow.
 
 ```sh
 git push

--- a/_config.yml
+++ b/_config.yml
@@ -9,6 +9,7 @@ permalink: /blog/:year/:month/:day/:title
 plugins:
   - jekyll-feed
   - jekyll-seo-tag
+  - jekyll-sitemap
 
 feed:
   path: feed.xml


### PR DESCRIPTION
Two findings from a repo maintenance pass:

1. **`/sitemap.xml` was 404** — site had no sitemap. Added `jekyll-sitemap` to the plugins list (whitelisted on GitHub Pages legacy build). Auto-generates `/sitemap.xml` at build, helps search engines discover all pages.

2. **`_plugins/tags.rb` is dead code on production.** GitHub Pages legacy mode doesn't run user plugins, so `/tags/` has been 404 since the plugin landed (PR #88). README now documents this and notes the GH Actions migration path. Not deleting the plugin or `_layouts/tag.html` — useful scaffolding for when the build moves to Actions.

Also cleaned up the stale `nav-touch-targets` branch (already merged via PR #90, deleted local + remote).