### PR TITLE
[prototype A] inline archive links on publications.md

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -489,6 +489,17 @@ main pre code { background: none; padding: 0; }
   scroll-margin-top: 80px;
 }
 .pub:last-of-type { border-bottom: 1px solid var(--rule); }
+.archive-link {
+  font-size: 0.7em;
+  margin-left: 0.15em;
+  vertical-align: super;
+  line-height: 0;
+  opacity: 0.45;
+  transition: opacity 0.15s var(--ease);
+}
+.archive-link a { color: var(--ink-3); text-decoration: none; border-bottom: none; }
+.archive-link:hover { opacity: 1; }
+.archive-link a:hover { color: var(--accent-blue); }
 .pub-anchor {
   position: absolute;
   left: -1.4em;

--- a/publications.md
+++ b/publications.md
@@ -26,10 +26,10 @@ description: "Publications by Aakash Solanki: public scholarship, interdisciplin
 <div class="pub" id="solanki-2025-express">
   <span class="yr">2025</span>
   <div class="main">
-    <p class="title"><a target="_blank" rel="noopener noreferrer" href="https://indianexpress.com/article/opinion/columns/india-start-ups-not-lacking-innovation-imagination-9974148/">India&rsquo;s start-ups are not lacking innovation but imagination</a></p>
+    <p class="title"><a target="_blank" rel="noopener noreferrer" href="https://indianexpress.com/article/opinion/columns/india-start-ups-not-lacking-innovation-imagination-9974148/">India&rsquo;s start-ups are not lacking innovation but imagination</a> <sup class="archive-link"><a target="_blank" rel="noopener noreferrer" href="https://web.archive.org/web/2/https://indianexpress.com/article/opinion/columns/india-start-ups-not-lacking-innovation-imagination-9974148/" aria-label="Wayback Machine archived copy">↗</a></sup></p>
     <p class="venue">The Indian Express.</p>
     <p class="blurb">An argument that India&rsquo;s start-up ecosystem suffers less from a deficit of innovation than from a poverty of imagination about what technology is for.</p>
-    <p class="note">With <a target="_blank" rel="noopener noreferrer" href="https://www.stevens.edu/profile/smertia">Sandeep Mertia</a>.</p>
+    <p class="note">With <a target="_blank" rel="noopener noreferrer" href="https://www.stevens.edu/profile/smertia">Sandeep Mertia</a> <sup class="archive-link"><a target="_blank" rel="noopener noreferrer" href="https://web.archive.org/web/2/https://www.stevens.edu/profile/smertia" aria-label="Wayback Machine archived copy">↗</a></sup>.</p>
   </div>
   <span class="tags">Op-ed</span>
   <a class="pub-anchor" href="#solanki-2025-express" aria-label="Permalink to this publication">#</a>
@@ -38,7 +38,7 @@ description: "Publications by Aakash Solanki: public scholarship, interdisciplin
 <div class="pub" id="solanki-2018-culanth">
   <span class="yr">2018</span>
   <div class="main">
-    <p class="title"><a target="_blank" rel="noopener noreferrer" href="https://culanth.org/fieldsights/suddenly-statistics">Suddenly, Statistics?</a></p>
+    <p class="title"><a target="_blank" rel="noopener noreferrer" href="https://culanth.org/fieldsights/suddenly-statistics">Suddenly, Statistics?</a> <sup class="archive-link"><a target="_blank" rel="noopener noreferrer" href="https://web.archive.org/web/2/https://culanth.org/fieldsights/suddenly-statistics" aria-label="Wayback Machine archived copy">↗</a></sup></p>
     <p class="venue">Cultural Anthropology Forum on Academic Precarity.</p>
     <p class="blurb">On the dissonance between anthropology&rsquo;s general suspicion of numbers and the discipline&rsquo;s sudden turn to statistics in confronting its own precarity.</p>
   </div>
@@ -51,10 +51,10 @@ description: "Publications by Aakash Solanki: public scholarship, interdisciplin
 <div class="pub" id="solanki-2026-chi">
   <span class="yr">2026</span>
   <div class="main">
-    <p class="title"><a target="_blank" rel="noopener noreferrer" href="https://doi.org/10.1145/3772318.3791530">&ldquo;Studying Up&rdquo; through Digital Ethnography: The Case of Conservative Caste Enclaves</a></p>
+    <p class="title"><a target="_blank" rel="noopener noreferrer" href="https://doi.org/10.1145/3772318.3791530">&ldquo;Studying Up&rdquo; through Digital Ethnography: The Case of Conservative Caste Enclaves</a> <sup class="archive-link"><a target="_blank" rel="noopener noreferrer" href="https://web.archive.org/web/2/https://doi.org/10.1145/3772318.3791530" aria-label="Wayback Machine archived copy">↗</a></sup></p>
     <p class="venue">Proceedings of the 2026 CHI Conference on Human Factors in Computing Systems. ACM.</p>
     <p class="blurb">Methodological reflections on digitally ethnographing online communities organised around caste, and the ethics of studying upward.</p>
-    <p class="note">With <a target="_blank" rel="noopener noreferrer" href="https://ischool.utoronto.ca/student-profile/ashique-ali-thuppilikkat/">Ashique Ali Thuppilikkat</a> and <a target="_blank" rel="noopener noreferrer" href="https://ischool.utoronto.ca/faculty-profile/priyank-chandra/">Priyank Chandra</a> (both at <a target="_blank" rel="noopener noreferrer" href="https://www.streetlab.tech/">Street Lab</a>).</p>
+    <p class="note">With <a target="_blank" rel="noopener noreferrer" href="https://ischool.utoronto.ca/student-profile/ashique-ali-thuppilikkat/">Ashique Ali Thuppilikkat</a> <sup class="archive-link"><a target="_blank" rel="noopener noreferrer" href="https://web.archive.org/web/2/https://ischool.utoronto.ca/student-profile/ashique-ali-thuppilikkat/" aria-label="Wayback Machine archived copy">↗</a></sup> and <a target="_blank" rel="noopener noreferrer" href="https://ischool.utoronto.ca/faculty-profile/priyank-chandra/">Priyank Chandra</a> <sup class="archive-link"><a target="_blank" rel="noopener noreferrer" href="https://web.archive.org/web/2/https://ischool.utoronto.ca/faculty-profile/priyank-chandra/" aria-label="Wayback Machine archived copy">↗</a></sup> (both at <a target="_blank" rel="noopener noreferrer" href="https://www.streetlab.tech/">Street Lab</a> <sup class="archive-link"><a target="_blank" rel="noopener noreferrer" href="https://web.archive.org/web/2/https://www.streetlab.tech/" aria-label="Wayback Machine archived copy">↗</a></sup>).</p>
   </div>
   <span class="tags">CHI</span>
   <a class="pub-anchor" href="#solanki-2026-chi" aria-label="Permalink to this publication">#</a>
@@ -73,10 +73,10 @@ description: "Publications by Aakash Solanki: public scholarship, interdisciplin
 <div class="pub" id="solanki-2016-epic">
   <span class="yr">2016</span>
   <div class="main">
-    <p class="title"><a target="_blank" rel="noopener noreferrer" href="https://doi.org/10.1111/1559-8918.2016.01107">Going Ethno in the Indian Bureaucracy</a></p>
+    <p class="title"><a target="_blank" rel="noopener noreferrer" href="https://doi.org/10.1111/1559-8918.2016.01107">Going Ethno in the Indian Bureaucracy</a> <sup class="archive-link"><a target="_blank" rel="noopener noreferrer" href="https://web.archive.org/web/2/https://doi.org/10.1111/1559-8918.2016.01107" aria-label="Wayback Machine archived copy">↗</a></sup></p>
     <p class="venue">Ethnographic Praxis in Industry Conference Proceedings 2016(1): 501–521.</p>
     <p class="blurb">Using ethnographic methods to assess digital literacy and state capacity inside Indian government agencies.</p>
-    <p class="note">With <a target="_blank" rel="noopener noreferrer" href="https://www.linkedin.com/in/sarveshtewari/">Sarvesh Tewari</a>.</p>
+    <p class="note">With <a target="_blank" rel="noopener noreferrer" href="https://www.linkedin.com/in/sarveshtewari/">Sarvesh Tewari</a> <sup class="archive-link"><a target="_blank" rel="noopener noreferrer" href="https://web.archive.org/web/2/https://www.linkedin.com/in/sarveshtewari/" aria-label="Wayback Machine archived copy">↗</a></sup>.</p>
   </div>
   <span class="tags">EPIC</span>
   <a class="pub-anchor" href="#solanki-2016-epic" aria-label="Permalink to this publication">#</a>
@@ -87,7 +87,7 @@ description: "Publications by Aakash Solanki: public scholarship, interdisciplin
 <div class="pub" id="solanki-2019-south-asia">
   <span class="yr">2019</span>
   <div class="main">
-    <p class="title"><a target="_blank" rel="noopener noreferrer" href="https://doi.org/10.1080/00856401.2019.1603262">Management of Performance and Performance of Management: Getting to Work on Time in the Indian Bureaucracy</a></p>
+    <p class="title"><a target="_blank" rel="noopener noreferrer" href="https://doi.org/10.1080/00856401.2019.1603262">Management of Performance and Performance of Management: Getting to Work on Time in the Indian Bureaucracy</a> <sup class="archive-link"><a target="_blank" rel="noopener noreferrer" href="https://web.archive.org/web/2/https://doi.org/10.1080/00856401.2019.1603262" aria-label="Wayback Machine archived copy">↗</a></sup></p>
     <p class="venue">South Asia: Journal of South Asian Studies, 42(3): 588–605.</p>
     <p class="blurb">How an Aadhaar-enabled biometric attendance system in a North Indian bureaucracy was partially circumvented by the staff it was meant to discipline — producing a performance of management rather than its substance.</p>
   </div>
@@ -119,10 +119,10 @@ description: "Publications by Aakash Solanki: public scholarship, interdisciplin
 <div class="pub" id="solanki-2020-untidy-data">
   <span class="yr">2020</span>
   <div class="main">
-    <p class="title"><a target="_blank" rel="noopener noreferrer" href="https://networkcultures.org/blog/publication/lives-of-data-essays-on-computational-cultures-from-india/">Untidy Data: Spreadsheet Practices in the Indian Bureaucracy</a></p>
-    <p class="venue">In Lives of Data: Essays on Computational Cultures from India, ed. <a target="_blank" rel="noopener noreferrer" href="https://www.stevens.edu/profile/smertia">Sandeep Mertia</a>. Theory on Demand 39. Amsterdam: Institute of Network Cultures.</p>
+    <p class="title"><a target="_blank" rel="noopener noreferrer" href="https://networkcultures.org/blog/publication/lives-of-data-essays-on-computational-cultures-from-india/">Untidy Data: Spreadsheet Practices in the Indian Bureaucracy</a> <sup class="archive-link"><a target="_blank" rel="noopener noreferrer" href="https://web.archive.org/web/2/https://networkcultures.org/blog/publication/lives-of-data-essays-on-computational-cultures-from-india/" aria-label="Wayback Machine archived copy">↗</a></sup></p>
+    <p class="venue">In Lives of Data: Essays on Computational Cultures from India, ed. <a target="_blank" rel="noopener noreferrer" href="https://www.stevens.edu/profile/smertia">Sandeep Mertia</a> <sup class="archive-link"><a target="_blank" rel="noopener noreferrer" href="https://web.archive.org/web/2/https://www.stevens.edu/profile/smertia" aria-label="Wayback Machine archived copy">↗</a></sup>. Theory on Demand 39. Amsterdam: Institute of Network Cultures.</p>
     <p class="blurb">On how spreadsheets — old and new media at once — produce the everyday work practices of an Indian bureaucracy.</p>
-    <p class="note"><a target="_blank" rel="noopener noreferrer" href="https://player.fm/series/new-books-in-technology-2421470/sandeep-mertia-lives-of-data-essays-on-computational-cultures-from-india-institute-of-networked-cultures-2020">→ Podcast discussion</a></p>
+    <p class="note"><a target="_blank" rel="noopener noreferrer" href="https://player.fm/series/new-books-in-technology-2421470/sandeep-mertia-lives-of-data-essays-on-computational-cultures-from-india-institute-of-networked-cultures-2020">→ Podcast discussion</a> <sup class="archive-link"><a target="_blank" rel="noopener noreferrer" href="https://web.archive.org/web/2/https://player.fm/series/new-books-in-technology-2421470/sandeep-mertia-lives-of-data-essays-on-computational-cultures-from-india-institute-of-networked-cultures-2020" aria-label="Wayback Machine archived copy">↗</a></sup></p>
   </div>
   <span class="tags">Chapter</span>
   <a class="pub-anchor" href="#solanki-2020-untidy-data" aria-label="Permalink to this publication">#</a>


### PR DESCRIPTION
DRAFT — visual prototype only, do not merge.

Variant A: small ↗ superscript added after every external link on publications.md, pointing to https://web.archive.org/web/2/<url> (latest Wayback snapshot).

Compare side-by-side with [PR #108](https://github.com/skishchampi/skishchampi.github.io/pull/108) which puts a separate "Archived copies" footer at the bottom instead.

Look at the diff or build locally to see how it reads. Pick the one you prefer; we'll roll the chosen pattern out site-wide and close the other.