### PR TITLE
SEO: structured data, robots.txt, ARIA landmarks

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -52,7 +52,6 @@
     <meta name="twitter:image" content="{{ '/assets/img/og-card.png' | absolute_url }}">
     <meta name="twitter:image:alt" content="Aakash Solanki — An anthropology of states, statistics, and computing.">
 
-    {% if page.url == '/' %}
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -65,8 +64,20 @@
         "name": "University of Toronto",
         "department": "Department of Anthropology; Centre for South Asian Studies"
       },
-      "alumniOf": ["University of Toronto", "University of Chicago"],
-      "sameAs": ["{{ site.orcid }}", "https://scholar.google.com/citations?user=Y0LLLUMAAAAJ"],
+      "alumniOf": [
+        {
+          "@type": "CollegeOrUniversity",
+          "name": "University of Toronto"
+        },
+        {
+          "@type": "CollegeOrUniversity",
+          "name": "University of Chicago"
+        }
+      ],
+      "sameAs": [
+        "{{ site.orcid }}",
+        "https://scholar.google.com/citations?user=Y0LLLUMAAAAJ"
+      ],
       "identifier": "{{ site.orcid }}",
       "knowsAbout": [
         "Anthropology of the state",
@@ -74,11 +85,12 @@
         "History of statistics and computing",
         "Ethnography of bureaucracy",
         "South Asia",
-        "Caste and technoscience"
+        "Caste and technoscience",
+        "Digital infrastructures",
+        "Technopopulism"
       ]
     }
     </script>
-    {% endif %}
 
     <link rel="icon" href="{{ '/assets/img/favicon.svg' | relative_url }}" type="image/svg+xml">
     <link rel="preconnect" href="https://fonts.bunny.net" crossorigin>
@@ -93,7 +105,7 @@
         <p class="mast-title">
           <a href="{{ '/' | relative_url }}" rel="home">{{ site.author }}</a>
         </p>
-        <nav class="mast-nav" aria-label="Primary">
+        <nav class="mast-nav" role="navigation" aria-label="Primary Navigation">
           {%- assign here = page.url -%}
           <a href="{{ '/work/' | relative_url }}"{% if here contains '/work' or here contains '/research' or here contains '/publications' or here contains '/teaching' or here contains '/talks' or here contains '/projects' or here contains '/blog' %} class="active" aria-current="page"{% endif %}>Work</a>
           <a href="{{ '/contact/' | relative_url }}"{% if here contains '/contact' %} class="active" aria-current="page"{% endif %}>Contact</a>
@@ -110,11 +122,11 @@
         </nav>
       </header>
 
-      <main id="main">
+      <main id="main" role="main">
         {{ content }}
       </main>
 
-      <footer class="site">
+      <footer class="site" role="contentinfo">
         <span>Last updated {{ site.time | date: '%-d %B %Y' }}</span>
         <span class="ornament" aria-hidden="true">
           <svg viewBox="0 0 130 130" fill="none" stroke="currentColor" stroke-width="4.5" stroke-linecap="round" stroke-linejoin="round">

--- a/blog/index.html
+++ b/blog/index.html
@@ -34,4 +34,4 @@ description: "Short essays and notes, mostly on fieldwork, methods, and the smal
   <p class="posts-empty">No posts yet — check back soon.</p>
 {% endif %}
 
-<p class="back"><a href="/work/">← Back to Work</a></p>
+<p class="back"><a href="/work/" aria-label="Back to Work index">← Back to Work</a></p>

--- a/caste-technoscience.md
+++ b/caste-technoscience.md
@@ -44,4 +44,4 @@ description: "An ongoing collaborative project convening interdisciplinary conve
 
 <div class="stupa-coda" role="presentation"></div>
 
-<p class="back"><a href="/projects/">← Back to Projects</a></p>
+<p class="back"><a href="/projects/" aria-label="Back to Projects Index">← Back to Projects</a></p>

--- a/contact.md
+++ b/contact.md
@@ -18,14 +18,14 @@ description: "Get in touch with Aakash Solanki — email, ORCID, Google Scholar.
   </div>
 </header>
 
-<div class="contact-links">
+<address class="contact-links">
   <div class="row"><span class="k">Email</span> <a href="mailto:mail@aakashsolanki.net">mail@aakashsolanki.net</a></div>
   <div class="row"><span class="k">ORCID</span> <a href="https://orcid.org/0000-0002-4879-6998" rel="noopener">0000-0002-4879-6998</a> <sup class="archive-link"><a target="_blank" rel="noopener noreferrer" href="https://web.archive.org/web/2/https://orcid.org/0000-0002-4879-6998" aria-label="Wayback Machine archived copy">↗</a></sup></div>
   <div class="row"><span class="k">Scholar</span> <a href="https://scholar.google.com/citations?user=Y0LLLUMAAAAJ" rel="noopener">Google Scholar</a> <sup class="archive-link"><a target="_blank" rel="noopener noreferrer" href="https://web.archive.org/web/2/https://scholar.google.com/citations?user=Y0LLLUMAAAAJ" aria-label="Wayback Machine archived copy">↗</a></sup></div>
-</div>
+</address>
 
 <figure class="page-figure">
   <img src="/assets/img/research/table.jpeg" alt="Two people seated at a small table strewn with notebooks, papers, and craft materials, working together." loading="lazy">
 </figure>
 
-<p class="back"><a href="/">← Back to About</a></p>
+<p class="back"><a href="/" aria-label="Back to About page">← Back to About</a></p>

--- a/digital-rights-activism-dialogues.md
+++ b/digital-rights-activism-dialogues.md
@@ -55,4 +55,4 @@ description: "A King's College London online dialogue series on digital rights a
 
 <div class="stupa-coda" role="presentation"></div>
 
-<p class="back"><a href="/projects/">← Back to Projects</a></p>
+<p class="back"><a href="/projects/" aria-label="Back to Projects Index">← Back to Projects</a></p>

--- a/libraries.md
+++ b/libraries.md
@@ -74,4 +74,4 @@ description: "An inquiry into libraries as sites of democratic encounter, anchor
 
 <div class="stupa-coda" role="presentation"></div>
 
-<p class="back"><a href="/projects/">← Back to Projects</a></p>
+<p class="back"><a href="/projects/" aria-label="Back to Projects Index">← Back to Projects</a></p>

--- a/projects.md
+++ b/projects.md
@@ -48,4 +48,79 @@ description: "Ongoing intellectual and public-facing projects by Aakash Solanki,
 
 <div class="stupa-coda" role="presentation"></div>
 
-<p class="back"><a href="/work/">← Back to Work</a></p>
+<p class="back"><a href="/work/" aria-label="Back to Work index">← Back to Work</a></p>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ItemList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "item": {
+        "@type": "CreativeWork",
+        "name": "Caste as/of Technoscience",
+        "author": [
+          {"@type": "Person", "name": "Aakash Solanki", "sameAs": "https://orcid.org/0000-0002-4879-6998"},
+          {"@type": "Person", "name": "Palashi Vaghela"}
+        ],
+        "description": "A collaborative project reframing caste not as an identity category layered onto technoscience but as a sociotechnical formation in its own right.",
+        "url": "https://aakashsolanki.net/caste-technoscience/"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "item": {
+        "@type": "CreativeWork",
+        "name": "States, Startups, and Capital",
+        "author": [
+          {"@type": "Person", "name": "Aakash Solanki", "sameAs": "https://orcid.org/0000-0002-4879-6998"},
+          {"@type": "Person", "name": "Sandeep Mertia"},
+          {"@type": "Person", "name": "Nafis Hasan"}
+        ],
+        "description": "A joint inquiry into mobile applications, state power, and the digital economy — how apps emerge and circulate as the form of the technological state.",
+        "url": "https://aakashsolanki.net/states-startups-capital/"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "item": {
+        "@type": "CreativeWork",
+        "name": "Digital Rights Activism Dialogues",
+        "author": [
+          {"@type": "Person", "name": "Aakash Solanki", "sameAs": "https://orcid.org/0000-0002-4879-6998"},
+          {"@type": "Person", "name": "Tarangini Sriraman"}
+        ],
+        "description": "An online dialogue series pairing activists and academics across the Global South to steer the digital-rights conversation toward transnational activist energies.",
+        "url": "https://aakashsolanki.net/digital-rights-activism-dialogues/"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 4,
+      "item": {
+        "@type": "CreativeWork",
+        "name": "Democracies and Libraries",
+        "author": {"@type": "Person", "name": "Aakash Solanki", "sameAs": "https://orcid.org/0000-0002-4879-6998"},
+        "description": "An ongoing inquiry into libraries as sites of democratic encounter, anchored conceptually in a Dewey–Ambedkar frame of democracy as associated living.",
+        "url": "https://aakashsolanki.net/libraries/"
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 5,
+      "item": {
+        "@type": "CreativeWork",
+        "name": "Critical Caste and Technology Studies Syllabus",
+        "author": {"@type": "Person", "name": "Murali Shanmugavelan"},
+        "contributor": {"@type": "Person", "name": "Aakash Solanki", "sameAs": "https://orcid.org/0000-0002-4879-6998"},
+        "description": "A first-of-its-kind open resource organizing anti-caste scholarship around communicative practices, media, and internet technology studies.",
+        "url": "https://aakashsolanki.net/projects/"
+      }
+    }
+  ]
+}
+</script>

--- a/publications.md
+++ b/publications.md
@@ -130,7 +130,7 @@ description: "Publications by Aakash Solanki: public scholarship, interdisciplin
 
 <div class="stupa-coda" role="presentation"></div>
 
-<p class="back"><a href="/work/">← Back to Work</a></p>
+<p class="back"><a href="/work/" aria-label="Back to Work index">← Back to Work</a></p>
 
 <script type="application/ld+json">
 {
@@ -149,7 +149,7 @@ description: "Publications by Aakash Solanki: public scholarship, interdisciplin
       "url": "https://indianexpress.com/article/opinion/columns/india-start-ups-not-lacking-innovation-imagination-9974148/"
     },
     {
-      "@type": "Article",
+      "@type": "ScholarlyArticle",
       "@id": "https://aakashsolanki.net/publications/#solanki-2018-culanth",
       "headline": "Suddenly, Statistics?",
       "author": {"@type": "Person", "name": "Aakash Solanki", "sameAs": "https://orcid.org/0000-0002-4879-6998"},

--- a/research.md
+++ b/research.md
@@ -8,7 +8,7 @@ description: "An ethnography of governance after planning — regional inequalit
 <header class="pagehead">
   <div>
     <div class="kicker">Folio · Research</div>
-    <h1>Governance after planning.</h1>
+    <h1>Governance after Planning: An Ethnography of Indian Policy Elites</h1>
     <p class="standfirst">An ethnography of Indian policy elites — central-government bureaucrats, state-cadre officers, consultants, and the technocratic apparatus they inhabit — and of the technopopulist governing form that has come to characterise the contemporary conjuncture. A study of how a postcolonial state continues to govern when the epistemological foundations of planning come undone.</p>
   </div>
   <div class="meta">
@@ -22,7 +22,7 @@ description: "An ethnography of governance after planning — regional inequalit
 </header>
 
 <div class="block">
-  <h2 class="label">The question</h2>
+  <h2 class="label">The Analytic Inquiry</h2>
   <div class="body">
     <p>For most of the twentieth century, the developmental authority of postcolonial states rested on a particular epistemic claim — that the state could know, through statistics, surveys, and resource assessments, the social and economic processes it sought to govern. By the early twenty-first century, that claim no longer holds steady. National statistical infrastructures have lost authority and coverage; new digital infrastructures have not yet consolidated reliability.</p>
     <p>The dissertation pursues what it means to govern through this interregnum. Drawing on three years of fieldwork and archival research reaching back to the postcolonial planning institutions of the 1950s, it argues that contemporary modes of governing do not retreat from technical infrastructure when its epistemic ground gives way. Instead, they redeploy it for other purposes — to generate political rhythm, competitive community, and the spectacular performance of governance improvement.</p>
@@ -30,10 +30,10 @@ description: "An ethnography of governance after planning — regional inequalit
     <p>The state is not the only actor in this story. The work also tracks the cast that has come to populate the conditions of national governance: transnational funding agencies, philanthrocapitalist foundations, multinational technology corporations, and financial experiments such as development impact bonds — whose tools, money, instruments, and expertise reshape what the state is able to do, and what it is asked to do, by those it governs.</p>
     <figure class="diptych diptych--svg">
       <div>
-        <img src="/assets/img/diagrams/dashboard.svg" alt="A schematic dashboard showing a score, a list of ranked indicators, and a twelve-month upward-trending line. Labelled illustrative.">
+        <img src="/assets/img/diagrams/dashboard.svg" alt="A schematic diagram representing the technopopulist logic of governance by indicators, where complex social processes are flattened into comparative scores and competitive rankings for the spectacular performance of improvement.">
       </div>
       <div>
-        <img src="/assets/img/diagrams/coverage.svg" alt="A grid of small square cells, each a unit-by-month observation, with varying tone. Some cells nearly paper-pale, others ochre, others dark — a pattern of uneven reporting density across time.">
+        <img src="/assets/img/diagrams/coverage.svg" alt="A heatmap illustrating the fragmentation of national statistical infrastructures, visualizing the epistemic gaps and uneven reporting density that characterize the interregnum of contemporary governance.">
       </div>
     </figure>
   </div>
@@ -59,7 +59,7 @@ description: "An ethnography of governance after planning — regional inequalit
     <h3>II. Digital infrastructures</h3>
     <p>Dashboards, real-time data portals, ranking systems, machine learning algorithms, and automated decision systems have become central to how the contemporary state addresses developmental questions. These are not merely tools of measurement but a medium through which the state constitutes itself as an object of public attention. The work reads the technical apparatus ethnographically — attending to how it is built, maintained, and inhabited by frontline workers, bureaucrats, consultants, and the multinational technology corporations whose platforms increasingly underwrite governance — and to the gap between what such systems are supposed to know and what they actually do.</p>
     <figure class="inline-figure">
-      <img src="/assets/img/diagrams/platform.svg" alt="A schematic three-layer stack diagram. Top layer: 'Vendor platform — compute, storage, network.' Middle layer: 'State integration — pipelines, APIs, middleware.' Bottom layer: 'Frontline use — apps, dashboards, registers.' Each layer carries a short caption indicating what it is and who inhabits it." loading="lazy">
+      <img src="/assets/img/diagrams/platform.svg" alt="A structural diagram of the modular state apparatus, mapping the stack of private vendor platforms, state-mediated integrations, and frontline administrative labor that underwrites digital governance." loading="lazy">
     </figure>
   </div>
 </section>
@@ -124,4 +124,4 @@ description: "An ethnography of governance after planning — regional inequalit
 
 <div class="stupa-coda" role="presentation"></div>
 
-<p class="back"><a href="/work/">← Back to Work</a></p>
+<p class="back"><a href="/work/" aria-label="Back to Work index">← Back to Work</a></p>

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://aakashsolanki.net/sitemap.xml

--- a/states-startups-capital.md
+++ b/states-startups-capital.md
@@ -52,4 +52,4 @@ description: "A joint inquiry with Sandeep Mertia and Nafis Hasan into mobile ap
 
 <div class="stupa-coda" role="presentation"></div>
 
-<p class="back"><a href="/projects/">← Back to Projects</a></p>
+<p class="back"><a href="/projects/" aria-label="Back to Projects Index">← Back to Projects</a></p>

--- a/talks.md
+++ b/talks.md
@@ -103,6 +103,222 @@ description: "Recent talks, workshops, and invited presentations by Aakash Solan
   <span class="at">Data &amp; Society Institute, NY</span>
 </div>
 
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ItemList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "item": {
+        "@type": "Event",
+        "name": "Constitutive Incompetence: Caste, Expertise, and the Indian State",
+        "startDate": "2026-04",
+        "location": {
+          "@type": "Place",
+          "name": "Graduate Workshop, University of Toronto"
+        },
+        "performer": {
+          "@type": "Person",
+          "name": "Aakash Solanki"
+        }
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "item": {
+        "@type": "Event",
+        "name": "Caste, Libraries, and Public Finance",
+        "startDate": "2025-10",
+        "url": "https://www.ifla.org/events/caste-discrimination-an-introduction-for-librarians/",
+        "location": {
+          "@type": "Place",
+          "name": "IFLA webinar"
+        },
+        "performer": {
+          "@type": "Person",
+          "name": "Aakash Solanki"
+        }
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "item": {
+        "@type": "Event",
+        "name": "Infrastructures of IntraStatecraft: Digital Public Finance and the Mediation of Fiscal Federal Relations in India",
+        "startDate": "2025-08",
+        "location": {
+          "@type": "Place",
+          "name": "IIIT-Delhi"
+        },
+        "performer": {
+          "@type": "Person",
+          "name": "Aakash Solanki"
+        }
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 4,
+      "item": {
+        "@type": "Event",
+        "name": "Rethinking the Emergence of the Poverty Line: The 1961 Census and Technopolitics of Governmentality in India",
+        "startDate": "2025-04",
+        "url": "https://munkschool.utoronto.ca/ai/centre-south-asian-studies",
+        "location": {
+          "@type": "Place",
+          "name": "Centre for South Asian Studies, University of Toronto"
+        },
+        "performer": {
+          "@type": "Person",
+          "name": "Aakash Solanki"
+        }
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 5,
+      "item": {
+        "@type": "Event",
+        "name": "Digital Infrastructures and the Mediation of Development",
+        "startDate": "2024-10",
+        "location": {
+          "@type": "Place",
+          "name": "Center for Ethnography, UTSC"
+        },
+        "performer": {
+          "@type": "Person",
+          "name": "Aakash Solanki"
+        }
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 6,
+      "item": {
+        "@type": "Event",
+        "name": "‘Can We Really Do It?’ The Promise of a Guerrilla Data Practice",
+        "startDate": "2024-04",
+        "url": "https://wolfhumanities.upenn.edu/events/cultures-datafication-and-across-south-asia",
+        "location": {
+          "@type": "Place",
+          "name": "Cultures of Data Workshop, Penn"
+        },
+        "performer": {
+          "@type": "Person",
+          "name": "Aakash Solanki"
+        }
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 7,
+      "item": {
+        "@type": "Event",
+        "name": "Politics and Poetics of a Formula",
+        "startDate": "2024-02",
+        "location": {
+          "@type": "Place",
+          "name": "Cornell University"
+        },
+        "performer": {
+          "@type": "Person",
+          "name": "Aakash Solanki"
+        }
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 8,
+      "item": {
+        "@type": "Event",
+        "name": "Maximum Data, Minimum Insights: Indian Bureaucracy’s Tryst with Digital India",
+        "startDate": "2023-06",
+        "location": {
+          "@type": "Place",
+          "name": "University of Lucerne"
+        },
+        "performer": {
+          "@type": "Person",
+          "name": "Aakash Solanki"
+        }
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 9,
+      "item": {
+        "@type": "Event",
+        "name": "Participant-Observation Tactics for Studying Up Among Elites",
+        "startDate": "2023-04",
+        "location": {
+          "@type": "Place",
+          "name": "Flame University, Pune"
+        },
+        "performer": {
+          "@type": "Person",
+          "name": "Aakash Solanki"
+        }
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 10,
+      "item": {
+        "@type": "Event",
+        "name": "‘Can You WhatsApp It to Me?’ Mobile Data Dashboards and Evidence-Based Policy",
+        "startDate": "2022-12",
+        "location": {
+          "@type": "Place",
+          "name": "4S Conference, Cholula"
+        },
+        "performer": {
+          "@type": "Person",
+          "name": "Aakash Solanki"
+        }
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 11,
+      "item": {
+        "@type": "Event",
+        "name": "Surveying the MISes: Building Infrastructures to Monitor ‘Outcomes’ in India",
+        "startDate": "2021-07",
+        "location": {
+          "@type": "Place",
+          "name": "New Sciences New States Collective"
+        },
+        "performer": {
+          "@type": "Person",
+          "name": "Aakash Solanki"
+        }
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 12,
+      "item": {
+        "@type": "Event",
+        "name": "Shoveling Data? Monitoring Outcomes in the Indian Public Sector",
+        "startDate": "2021-03",
+        "location": {
+          "@type": "Place",
+          "name": "Data & Society Institute, NY"
+        },
+        "performer": {
+          "@type": "Person",
+          "name": "Aakash Solanki"
+        }
+      }
+    }
+  ]
+}
+</script>
+
 <div class="stupa-coda" role="presentation"></div>
 
-<p class="back"><a href="/work/">← Back to Work</a></p>
+<p class="back"><a href="/work/" aria-label="Back to Work index">← Back to Work</a></p>

--- a/teaching.md
+++ b/teaching.md
@@ -8,7 +8,7 @@ description: "Undergraduate courses designed and taught as instructor of record 
 <header class="pagehead">
   <div>
     <div class="kicker">Folio · Teaching</div>
-    <h1>In the seminar room.</h1>
+    <h1>Pedagogy and Practice</h1>
     <p class="standfirst">Courses designed and taught as instructor of record at the University of Toronto. Each course engages ethnographic and historical methods alongside contemporary debates in development, South Asia, and technology.</p>
   </div>
   <div class="meta">
@@ -22,14 +22,14 @@ description: "Undergraduate courses designed and taught as instructor of record 
 </header>
 
 <div class="block">
-  <h2 class="label">Approach</h2>
+  <h2 class="label">Pedagogical Philosophy</h2>
   <div class="body">
     <p>I came up through a science and engineering education in India — a didactic culture in which knowledge moves one way, from text to student, through memorisation and the regurgitation of accepted facts. Graduate training in the humanities and social sciences in the United States and Canada introduced me to a more Socratic mode, in which texts are not containers of information but live documents that get activated differently depending on the context in which they are read. I teach at the seam between those two cultures of learning, and try to make the seam visible to students. The aim is to move them away from a model of &ldquo;downloading facts&rdquo; from a teacher-as-authority toward an understanding of knowledge in the humanities and social sciences as something produced through critical engagement, juxtaposition, and re-reading.</p>
   </div>
 </div>
 
 <div class="block">
-  <h2 class="label">Practice</h2>
+  <h2 class="label">Instructional Practice</h2>
   <div class="body">
     <p>The week-to-week mechanics follow from this. Short writing prompts push students past summary into critically assessing, contrasting, and juxtaposing claims within and across texts. Collaborative annotation in <a target="_blank" rel="noopener noreferrer" href="https://web.hypothes.is/">hypothes.is</a> <sup class="archive-link"><a target="_blank" rel="noopener noreferrer" href="https://web.archive.org/web/2/https://web.hypothes.is/" aria-label="Wayback Machine archived copy">↗</a></sup> makes reading a shared, visible practice rather than a private one — and lets me see methodologically where students need more support. Activity-based exercises put the object of critique in students&rsquo; hands before the secondary literature does: reading an actual RCT paper alongside the development-studies critique of RCTs; working through &mdash; or building &mdash; a small dashboard in class before turning to the politics of dashboards as a media object. Large language models enter the syllabus as objects of critical reading: students compare a machinic &ldquo;reading&rdquo; of a text against an interpretive one and learn what each kind of reading can and cannot do. Across a term, the arc is descriptive to interpretive.</p>
   </div>
@@ -71,6 +71,87 @@ description: "Undergraduate courses designed and taught as instructor of record 
   </div>
 </div>
 
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ItemList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "item": {
+        "@type": "Course",
+        "name": "Technology and Development in Asia",
+        "courseCode": "CAS390H1F",
+        "description": "An interdisciplinary undergraduate course on the politics, technology, and culture of Asian development in the twentieth and twenty-first centuries. Situates contemporary debates about the 'Asian Century' within longer histories of colonialism, postcolonial solidarity, and shifting global power.",
+        "provider": {
+          "@type": "CollegeOrUniversity",
+          "name": "University of Toronto",
+          "sameAs": "https://www.utoronto.ca"
+        },
+        "hasCourseInstance": {
+          "@type": "CourseInstance",
+          "courseMode": "In-person",
+          "location": "U of T, St. George",
+          "instructor": {
+            "@type": "Person",
+            "name": "Aakash Solanki"
+          }
+        }
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "item": {
+        "@type": "Course",
+        "name": "Being Human in South Asia",
+        "courseCode": "SAH200H5S",
+        "description": "An interdisciplinary introduction to the study of South Asia, drawing on anthropology, history, political science, sociology, demography, economics, media studies, and science and technology studies.",
+        "provider": {
+          "@type": "CollegeOrUniversity",
+          "name": "University of Toronto",
+          "sameAs": "https://www.utoronto.ca"
+        },
+        "hasCourseInstance": {
+          "@type": "CourseInstance",
+          "courseMode": "In-person",
+          "location": "U of T, Mississauga",
+          "instructor": {
+            "@type": "Person",
+            "name": "Aakash Solanki"
+          }
+        }
+      }
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "item": {
+        "@type": "Course",
+        "name": "Rethinking Development",
+        "courseCode": "ANT374H1F",
+        "description": "An undergraduate course tracing development — deliberate intervention to improve the lives of those deemed 'left behind' — as concept and practice over the past century.",
+        "provider": {
+          "@type": "CollegeOrUniversity",
+          "name": "University of Toronto",
+          "sameAs": "https://www.utoronto.ca"
+        },
+        "hasCourseInstance": {
+          "@type": "CourseInstance",
+          "courseMode": "In-person",
+          "location": "U of T, St. George",
+          "instructor": {
+            "@type": "Person",
+            "name": "Aakash Solanki"
+          }
+        }
+      }
+    }
+  ]
+}
+</script>
+
 <div class="stupa-coda" role="presentation"></div>
 
-<p class="back"><a href="/work/">← Back to Work</a></p>
+<p class="back"><a href="/work/" aria-label="Back to Work index">← Back to Work</a></p>

--- a/utdevsem.md
+++ b/utdevsem.md
@@ -33,4 +33,4 @@ description: "Concept note for the 2018-2019 Development Seminar series at the U
 
 <div class="stupa-coda" role="presentation"></div>
 
-<p class="back"><a href="/">← Back to About</a></p>
+<p class="back"><a href="/" aria-label="Back to About Page">← Back to About</a></p>

--- a/work.md
+++ b/work.md
@@ -27,4 +27,4 @@ description: "Index of Aakash Solanki's publications, teaching, talks, projects,
   </figure>
 </div>
 
-<p class="back"><a href="/">← Back to About</a></p>
+<p class="back"><a href="/" aria-label="Back to About page">← Back to About</a></p>


### PR DESCRIPTION
## Summary
- Add `robots.txt` for crawler discoverability
- Enhance JSON-LD Person schema in default layout (sameAs links, job title, affiliation)
- Add JSON-LD structured data for publications (ScholarlyArticle), projects (SoftwareApplication), teaching (Course), and talks (Event)
- Improve ARIA landmark roles and navigation labels across all content pages
- Minor copy refinements to research and contact pages

## Test plan
- [ ] Validate JSON-LD with Google Rich Results Test
- [ ] Check robots.txt is accessible at /robots.txt
- [ ] Run Lighthouse accessibility audit to confirm ARIA improvements