### PR TITLE
fix(links): silence external-link-check false positives

### DIFF
--- a/.github/workflows/external-links.yml
+++ b/.github/workflows/external-links.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           htmlproofer ./_site \
             --ignore-empty-alt \
-            --ignore-urls "/^\/freelibraries4all/,/aakashsolanki\.net/,/linkedin\.com/,/doi\.org/,/player\.fm/,/ifla\.org/" \
+            --ignore-urls "/^\/freelibraries4all/,/aakashsolanki\.net/,/linkedin\.com/,/doi\.org/,/player\.fm/,/ifla\.org/,/anthropology\.utoronto\.ca/,/vidhilegalpolicy\.in/" \
             --ignore-status-codes "999,429" \
             --hydra '{"max_concurrency": 5}' \
             --typhoeus '{"timeout": 30, "connecttimeout": 15, "followlocation": true, "headers": {"User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36", "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8", "Accept-Language": "en-US,en;q=0.9"}}'

--- a/contact.md
+++ b/contact.md
@@ -21,7 +21,7 @@ description: "Get in touch with Aakash Solanki — email, ORCID, Google Scholar.
 <address class="contact-links">
   <div class="row"><span class="k">Email</span> <a href="mailto:mail@aakashsolanki.net">mail@aakashsolanki.net</a></div>
   <div class="row"><span class="k">ORCID</span> <a href="https://orcid.org/0000-0002-4879-6998" rel="noopener">0000-0002-4879-6998</a> <sup class="archive-link"><a target="_blank" rel="noopener noreferrer" href="https://web.archive.org/web/2/https://orcid.org/0000-0002-4879-6998" aria-label="Wayback Machine archived copy">↗</a></sup></div>
-  <div class="row"><span class="k">Scholar</span> <a href="https://scholar.google.com/citations?user=Y0LLLUMAAAAJ" rel="noopener">Google Scholar</a> <sup class="archive-link"><a target="_blank" rel="noopener noreferrer" href="https://web.archive.org/web/2/https://scholar.google.com/citations?user=Y0LLLUMAAAAJ" aria-label="Wayback Machine archived copy">↗</a></sup></div>
+  <div class="row"><span class="k">Scholar</span> <a href="https://scholar.google.com/citations?user=Y0LLLUMAAAAJ" rel="noopener">Google Scholar</a></div>
 </address>
 
 <figure class="page-figure">


### PR DESCRIPTION
The weekly **External link check** cron has been failing on 3 links, none of which are real breakages on the site:

| Link | "Failure" | Reality |
|---|---|---|
| `web.archive.org/web/2/…scholar.google.com…` | 404 | Google Scholar blocks the Wayback Machine — this archive snapshot will never exist |
| `anthropology.utoronto.ca/.../aakash-solanki` | 403 | Site bot-block; works in a browser |
| `vidhilegalpolicy.in/.../public-libraries/` | conn error | Cloudflare bot-block; works in a browser |

### Changes
- **contact.md** — remove the un-archivable Wayback `↗` next to Google Scholar (the live Scholar link stays).
- **external-links.yml** — add `anthropology.utoronto.ca` and `vidhilegalpolicy.in` to `--ignore-urls` (same bot/Cloudflare category already noted in the workflow comment).

The weekly check keeps running and still catches genuine link rot — it just stops emailing on these known false positives.